### PR TITLE
fix(guard): reject spend ceilings gated on a forgeable header identity (P0)

### DIFF
--- a/x402/src/sdk/guard.ts
+++ b/x402/src/sdk/guard.ts
@@ -356,14 +356,36 @@ export function createDnaGuard(options: DnaGuardControllerOptions = {}): DnaGuar
 
       try {
         if (amountAtomic) {
-          // SECURITY: warn when spend ceilings are enforced against an unverified header-sourced identity.
-          // Header values are client-supplied and can be forged. Spend ceilings gated on them are not
-          // tamper-proof until replaced by verified identities (payment proof, API key, agent passport).
-          const actorSource: GuardIdentitySource = (actor as { guardIdentitySource?: GuardIdentitySource }).guardIdentitySource ?? "header";
-          if (spendCeilings && actorSource === "header") {
-            console.warn(
-              `[guard] identitySource=header for spend ceiling check — identity is unverified and may be forged (providerId=${providerId} endpointId=${endpointId})`,
-            );
+          // SECURITY (P0): the default request extractor sets guardIdentitySource="header" when it
+          // reads the client-supplied x-dna-* headers, which are forgeable. Enforcing a per-identity
+          // spend ceiling against a forgeable identity is not tamper-proof — a caller can rotate the
+          // headers to mint a fresh identity and reset the ceiling on every request. A forgeable
+          // identity must never be treated as authoritative for a financial limit: fail-closed
+          // deployments reject it; fail-open deployments record the gap but stay permissive (they
+          // explicitly opt into that risk). A custom integrator-supplied actor that omits
+          // guardIdentitySource is the integrator's own contract and is left untouched.
+          const rawIdentitySource: GuardIdentitySource | undefined =
+            (actor as { guardIdentitySource?: GuardIdentitySource }).guardIdentitySource;
+          const actorSource: GuardIdentitySource = rawIdentitySource ?? "header";
+          if (spendCeilings && rawIdentitySource === "header") {
+            recordGuardEvent("GUARD_SPEND_BLOCKED", {
+              providerId,
+              endpointId,
+              actor,
+              amountAtomic,
+              reason: "spend_ceiling_unverified_identity",
+              meta: {
+                enforced: failMode === "fail-closed",
+                identitySource: actorSource,
+              },
+            });
+            if (failMode === "fail-closed") {
+              failClosed(403, {
+                error: "dna_guard_unverified_identity",
+                reason: "spend_ceiling_requires_verified_identity",
+              });
+              return;
+            }
           }
           const spendDecision: DnaGuardSpendDecision | undefined = spendCeilings
             ? ledger.checkSpend(actor, amountAtomic, spendCeilings)

--- a/x402/tests/guard.middleware.test.ts
+++ b/x402/tests/guard.middleware.test.ts
@@ -140,6 +140,33 @@ describe("DNA Guard middleware and router", () => {
     expect(auditLog.query({ kind: "GUARD_SPEND_BLOCKED" })).toHaveLength(1);
   });
 
+  it("rejects spend ceilings enforced against a forgeable header identity in fail-closed mode (P0)", () => {
+    const auditLog = new AuditLogger({ stdout: false });
+    const guard = createDnaGuard({ auditLog });
+    // No custom actor -> defaultActorFromRequest derives identity from the forgeable x-dna-* headers
+    // and tags guardIdentitySource="header"; a spoofed buyer would otherwise sit under the ceiling.
+    const protectedRoute = guard.protect({
+      providerId: "seller-p0",
+      endpointId: "chat",
+      amountAtomic: "10",
+      spendCeilings: { buyerAtomic: "1000000" },
+      failMode: "fail-closed",
+    });
+
+    const req = makeRequest({ headers: { "x-dna-buyer-id": "forged-buyer" }, path: "/p0" });
+    const res = makeResponse();
+    const nextCalled = runMiddleware(protectedRoute, req, res, (_req, response) => {
+      response.json({ ok: true });
+    });
+
+    expect(nextCalled).toBe(false);
+    expect((res as unknown as MockResponse).statusCode).toBe(403);
+    expect((res as unknown as MockResponse).body).toMatchObject({
+      error: "dna_guard_unverified_identity",
+      reason: "spend_ceiling_requires_verified_identity",
+    });
+  });
+
   it("fails open on guard runtime errors and exposes receipt verification state", () => {
     const auditLog = new AuditLogger({ stdout: false });
     const guard = createDnaGuard({ auditLog });


### PR DESCRIPTION
P0 spend-ceiling bypass: defaultActorFromRequest tags identity guardIdentitySource="header" when it reads client-supplied x-dna-* headers, which are forgeable. The guard previously only warned and still enforced per-identity spend ceilings against that forgeable identity, so a caller could rotate x-dna-buyer-id to mint a fresh identity and reset the ceiling every request.

Fix (lean, enforcement-point only, no verifier change): when a spend ceiling would be enforced against an explicit header identity, fail-closed deployments reject with 403 dna_guard_unverified_identity; fail-open deployments record the gap but stay permissive. Custom integrator-supplied actors that omit guardIdentitySource are untouched.

Tests: adds a forge-rejection case; all 4 guard suites pass (23 tests); tsc --noEmit clean.