### PR TITLE
docs(snarkpack): fix stale ceremony artifact path

### DIFF
--- a/docs/SNARKPACK_BATCH_SETTLEMENT.md
+++ b/docs/SNARKPACK_BATCH_SETTLEMENT.md
@@ -98,7 +98,7 @@ A Node.js / Rust binary that:
 - Accepts N Groth16 proof bundles (matching our existing 256-byte proof format from
   `dark-bn254-proof-gen`).
 - Loads the SnarkPack SRS (a structured reference string with G1 and G2 commitment keys — can be
-  derived from the Powers of Tau ceremony output already in `evidence/ceremony/`).
+  derived from the Powers of Tau ceremony output already in `evidence/zk/`).
 - Runs the GIPA reduction to produce the aggregate proof blob.
 - Outputs: `{ aggregate_proof: Uint8Array, merged_pub_inputs: Uint8Array[], srs_digest: string }`.
 


### PR DESCRIPTION
The SnarkPack SRS note pointed at evidence/ceremony/, which does not exist; the Powers-of-Tau / ceremony artifacts live in evidence/zk/ (ceremony-v2.json, vk.json). One-line doc path fix.