### PR TITLE
fix: dead mainnet config + audit-date/buy-pressure/burn wording + scoped 'first'

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,8 +1,13 @@
-# Full Audit Report
+# Devnet Smoke-Test Report
+
+> This is an automated devnet smoke/integration test of deploy, pause-flag, and
+> anchoring behavior — **not a security audit**. It has not been performed by any
+> third-party auditor and must not be cited as a security review. The programs are
+> UNAUDITED. "PASS" below means the smoke-test steps ran successfully on devnet.
 
 Generated: 2026-05-27T04:00:40.822Z
 Cluster: devnet
-Overall: PASS
+Overall: PASS (smoke test)
 
 ## Steps
 - Deploy estimate: PASS - Deploy estimate report generated
@@ -16,7 +21,7 @@ Overall: PASS
 - Anchoring evidence: PASS - Anchoring evidence confirmed for 3hjamjwumezcJs6d7aiHiPNbUBTD9VvAVnZHxkuUm68h9exw1ANXhFUHMnwNKhHW1aTTYMiBTecWvBJZn6UqwQSN
 
 ## Artifacts
-- audit json: <repo-root>\reports\audit-2026-05-27T04-00-23.174Z.json
+- smoke-test json: <repo-root>\reports\audit-2026-05-27T04-00-23.174Z.json
 - deploy estimate: <repo-root>\reports\estimate-deploy-cost-2026-05-27T04-00-23.174Z.json
 - deploy ledger: <repo-root>\reports\deploy-ledger-2026-05-14T11-26-56.475Z.json
 - close buffers: <repo-root>\reports\close-buffers-2026-05-27T04-00-23.174Z.json

--- a/configs/mainnet.commercial.json
+++ b/configs/mainnet.commercial.json
@@ -21,7 +21,7 @@
     "mintGate": "5jduvBZggszFeE7uxxNrvZAp8pJxzqtgzBGqg12fKhC1",
     "receiptAnchor": "6HSRGivdYR5D7yTDy1TFMCM8h3LzXxRtKU1RA3RnCMRN",
     "proofGate": "PmSCTuehX1MYxf8GNsGsUZySYTtqWAtuTt3N2xZLpw2",
-    "nullRegistrar": "GRasGMtZsvvymw5BqY1ZpG1Hy15XEK7nz4Z6fTA6cMP8"
+    "nullRegistrar": "H4wbFJucY9shJt95N8Bra532Z4nnkKhGEfqWvLcYfuDm"
   },
   "nullMint": "8EeDdvCRmFAzVD4takkBrNNwkeUTUQh4MscRK5Fzpump",
   "rpcUrl": "https://api.mainnet-beta.solana.com"

--- a/docs/GRANT_APPLICATION.md
+++ b/docs/GRANT_APPLICATION.md
@@ -51,7 +51,7 @@ All 8 programs deployed 2026-05-29 to Solana mainnet-beta, all verified executab
 
 We do not claim to be first with passkeys on Solana, first with ZK on Solana, or first with x402 (Coinbase and others exist). What we believe is new:
 
-**First Solana x402 micropayment rail for AI agents.** No prior Solana implementation closes the loop: agent makes a request, receives a 402, pays on Solana, resource is delivered — without backend custody or intermediate signers.
+**To our knowledge, the first known open-source Solana stack to combine x402 + Groth16 private settlement + Agent Passport.** We are not aware of a prior Solana implementation that closes the loop — agent makes a request, receives a 402, pays on Solana, resource is delivered, without backend custody or intermediate signers — as a single permissively-licensed stack alongside biometric agent identity and compressed private receipts.
 
 **First biometric passkey identity verification on Solana with challenge-rotation sign-in.** A P-256 public key bound to a PDA via SIMD-0075 precompile, with per-request challenge rotation, tested on real hardware (Solana Seeker). This is agent identity attestation — distinct from passkey wallets.
 

--- a/docs/NULL_REGISTRAR.md
+++ b/docs/NULL_REGISTRAR.md
@@ -90,27 +90,27 @@ Emits the current `content_hash` as a program log for indexers and RPC callers. 
 
 ---
 
-## The NULL Flywheel
+## Registration Fees → Protocol Treasury
 
-Registration costs NULL tokens. Every `.null` domain minted is demand for NULL:
+Registration costs a fee (SOL-priced, ~0.01 SOL, config-set, free during the pilot). The fee **transfers to the protocol treasury** and is **never burned**. This is a **utility** flow that funds protocol operations — it is **not** a token supply/demand, buy-pressure, or price-appreciation mechanism:
 
 ```
 Agent needs identity
        |
        v
-Buys NULL on market
+Pays registration fee
        |
        v
-Pays registration fee → NULL treasury
+Fee transfers → protocol treasury (never burned)
        |
        v
 Domain minted on-chain forever
        |
        v
-Protocol earns NULL → backs ecosystem
+Treasury funds protocol operations
 ```
 
-The more agents, the more domains. The more domains, the more NULL demand. The treasury accumulates NULL that backs protocol operations and NULL Mining rewards.
+The more agents, the more domains registered. Fees accrue to the treasury to fund protocol operations. No buy-pressure, burn, or price-appreciation claims are made.
 
 ---
 

--- a/docs/WEB0_MASTER_PLAN.md
+++ b/docs/WEB0_MASTER_PLAN.md
@@ -211,12 +211,15 @@ SDK → `npm publish` both → upload to ClawHub as two separate listings.
 - $NULL is **fixed supply, not minted/emitted** — launched ~6mo ago on pump.fun.
 - Vault is `NOT_PRODUCTION` / devnet — nothing live yet.
 
-### `.null` registration → NULL demand
+### `.null` registration → protocol treasury (utility, not price)
 
-Every `.null` domain costs NULL to register (when `IS_MAINNET_READY = true`):
+Every `.null` domain costs a registration fee (SOL-priced, ~0.01 SOL, config-set,
+free in pilot). The fee **transfers to the protocol treasury** to fund operations —
+it is **never burned**, and this is a **utility** flow, not a supply/demand or
+price-appreciation mechanism. **No buy-pressure / price language** (Phase 1 rule):
 ```
-Agent needs identity → buys NULL → pays fee → domain minted forever
-→ protocol earns NULL → backs ecosystem → more agents → more NULL demand
+Agent needs identity → pays registration fee → domain minted forever
+→ fee accrues to protocol treasury → funds protocol operations
 ```
 
 ### DePIN angle — "NULL Mining Network"
@@ -267,8 +270,9 @@ Liquefy 33–61× JSON, 1.4–6× vs Zstd · Agent Passport T0-2 · x402 receipt
 "first to COMBINE x402+Groth16+Passport+receipt anchoring" · nebula VMAF 88.1 ·
 parad0x.null live on Arweave (permanent, seizure-resistant).
 
-**RED:** "audited" · "first x402/shielded pool" · buyback/price language (Phase 1) ·
-invented ratios. Always say: *"Public Beta, non-custodial, capped, audit Q3 2026."*
+**RED:** "audited" · "audit scheduled" / any audit date · "first x402/shielded pool" ·
+buyback/price language (Phase 1) · invented ratios. Always say: *"Public Beta,
+non-custodial, capped, unaudited (not yet audited)."*
 
 ---
 

--- a/packages/null-miner-sdk/src/index.ts
+++ b/packages/null-miner-sdk/src/index.ts
@@ -4,7 +4,8 @@
  * Universal NULL Miner SDK — plug into any app, users earn USDC autonomously,
  * platform collects fees, we take tx dust.
  *
- * First on Solana. Built on DNA x402 + Dark NULL.
+ * To our knowledge, the first known open-source Solana stack to COMBINE
+ * x402 + Groth16 private settlement + Agent Passport. Built on DNA x402 + Dark NULL.
  *
  * Quick start:
  *   import { NullMiner } from "null-miner-sdk";

--- a/programs/null_registrar/src/lib.rs
+++ b/programs/null_registrar/src/lib.rs
@@ -1,8 +1,9 @@
 //! null-registrar — .null domain name registrar for Solana
 //!
 //! The .null namespace belongs to no government, ICANN, or corporation.
-//! Domains are registered by burning/transferring NULL tokens and resolve
-//! to Arweave/IPFS content hashes — permanent, unstoppable, agent-native.
+//! Domains are registered by paying a fee that TRANSFERS to the protocol
+//! treasury (never burned), and resolve to Arweave/IPFS content hashes —
+//! permanent, unstoppable, agent-native.
 //!
 //! ⚠️  EXTERNALLY UNAUDITED — test pilot. Not reviewed by any third-party auditor.
 //!    Deploy: `cargo build-sbf --features mainnet`


### PR DESCRIPTION
Repoints nullRegistrar from the closed v0 to live v1; removes 'audit Q3 2026' + NULL buy-pressure/burn framing; scopes the 'first on Solana' claim. UNAUDITED, no audit scheduled.