### PR TITLE
docs: mark null_registrar source as legacy v1 (live is v2)

### DIFF
--- a/docs/NULL_REGISTRAR.md
+++ b/docs/NULL_REGISTRAR.md
@@ -1,5 +1,10 @@
 # .null Domain Registrar
 
+> ⚠️ **Legacy/illustrative.** This documents the v1 (NULL-priced, `IS_MAINNET_READY`) design.
+> The **live mainnet** registrar is **v2** — **SOL-priced (~0.01 SOL all-in), config-driven via
+> `SetConfig`, free during the pilot** — at `H4wbFJucY9shJt95N8Bra532Z4nnkKhGEfqWvLcYfuDm`.
+> See the canonical v2 source/spec in the web0-internal repo.
+
 **Program**: `programs/null_registrar`
 **Status**: Pre-audit pilot — `IS_MAINNET_READY = false`
 

--- a/programs/null_registrar/src/lib.rs
+++ b/programs/null_registrar/src/lib.rs
@@ -5,6 +5,12 @@
 //! treasury (never burned), and resolve to Arweave/IPFS content hashes —
 //! permanent, unstoppable, agent-native.
 //!
+//! ⚠️  LEGACY / ILLUSTRATIVE SOURCE — NOT the live mainnet program.
+//!     This is the v1 design (NULL-priced, IS_MAINNET_READY gate). The LIVE mainnet
+//!     registrar is v2 — SOL-priced (~0.01 SOL all-in), config-driven via SetConfig,
+//!     free during the pilot — at H4wbFJucY9shJt95N8Bra532Z4nnkKhGEfqWvLcYfuDm.
+//!     Canonical v2 source/spec: the web0-internal repo. Do NOT deploy this v1 source.
+//!
 //! ⚠️  EXTERNALLY UNAUDITED — test pilot. Not reviewed by any third-party auditor.
 //!    Deploy: `cargo build-sbf --features mainnet`
 //!


### PR DESCRIPTION
Adds banners to lib.rs + NULL_REGISTRAR.md noting the committed source is the legacy v1 (NULL-priced); the live mainnet program is v2 (SOL-priced, SetConfig, H4wbFJ...).