### PR TITLE
chore(skills): MOVED pointers — openclaw-* skills' canonical home is now openclaw-skills

### DIFF
--- a/packages/openclaw-context-capsule/README.md
+++ b/packages/openclaw-context-capsule/README.md
@@ -1,5 +1,10 @@
 # context-capsule — OpenClaw ContextEngine plugin
 
+> ⚠️ **MOVED — this copy is frozen.** The canonical home of this skill is now
+> [openclaw-skills/skills/context-capsule](https://github.com/Parad0x-Labs/openclaw-skills/tree/main/skills/context-capsule).
+> Install from, file issues against, and contribute to openclaw-skills; this
+> directory remains only as a historical pointer and will not receive updates.
+
 Compresses agent session history before it reaches the LLM. **Self-contained:**
 the compression core is vendored inline (`src/compression.ts`) — no external
 runtime dependency, and no network, file-system, or on-chain access. It uses

--- a/packages/openclaw-context-capsule/SKILL.md
+++ b/packages/openclaw-context-capsule/SKILL.md
@@ -1,5 +1,9 @@
 # Context Capsule
 
+> ⚠️ **MOVED:** canonical home is
+> [openclaw-skills/skills/context-capsule](https://github.com/Parad0x-Labs/openclaw-skills/tree/main/skills/context-capsule).
+> This copy is frozen.
+
 Compress agent session history ~99% before it hits the LLM, so you stop paying
 to re-send the whole transcript on every call. Works with any model — Claude,
 GPT, Ollama, Mistral, LM Studio.

--- a/packages/openclaw-x402-gate/README.md
+++ b/packages/openclaw-x402-gate/README.md
@@ -1,6 +1,9 @@
 # openclaw-x402-gate — charge other agents with x402 on Solana
 
-> 💜 [Star it on ClawHub](https://clawhub.ai/parad0x-labs/x402-gate) if it earns its keep.
+> ⚠️ **MOVED — this copy is frozen.** The canonical home of this skill is now
+> [openclaw-skills/skills/x402-gate](https://github.com/Parad0x-Labs/openclaw-skills/tree/main/skills/x402-gate).
+> Install from, file issues against, and contribute to openclaw-skills; this
+> directory remains only as a historical pointer and will not receive updates.
 
 Turn any OpenClaw skill or API into a paid endpoint. Mint an HTTP **402 Payment
 Required** challenge, verify the payment, then serve. Funds settle **straight to
@@ -20,8 +23,8 @@ Solana mainnet**.
   well-formed header. The check binds to the unique receipt hash in the tx memo,
   so proofs can't be replayed against a different charge.
 
-> **Status: Public Beta.** Non-custodial, external audit scheduled Q3 2026.
-> Not yet audited.
+> **Status: Public Beta.** Non-custodial, **unaudited** — no external audit has
+> been completed or scheduled.
 
 ## The two tools
 

--- a/packages/openclaw-x402-gate/SKILL.md
+++ b/packages/openclaw-x402-gate/SKILL.md
@@ -1,5 +1,9 @@
 # x402 Gate
 
+> ⚠️ **MOVED:** canonical home is
+> [openclaw-skills/skills/x402-gate](https://github.com/Parad0x-Labs/openclaw-skills/tree/main/skills/x402-gate).
+> This copy is frozen.
+
 **Charge other agents** for your OpenClaw skill or API. Mint a 402 challenge,
 verify the payment, then serve — funds settle straight to your own Solana wallet.
 
@@ -30,7 +34,7 @@ verify the payment, then serve — funds settle straight to your own Solana wall
 - **Replay-resistant** — verification binds to a unique per-payment receipt hash
   carried in the on-chain memo.
 
-> **Public Beta** — non-custodial, external audit scheduled Q3 2026. Not yet audited.
+> **Public Beta** — non-custodial, **unaudited** (no external audit completed or scheduled).
 
 ## Pairs with
 

--- a/packages/openclaw-x402-gate/src/index.ts
+++ b/packages/openclaw-x402-gate/src/index.ts
@@ -13,7 +13,7 @@
  *   - Revenue-grade gating: set requireOnChain=true so a payment is accepted only
  *     after the transaction is confirmed on Solana (not just a well-formed header).
  *
- * Status: Public Beta. Non-custodial, external audit scheduled Q3 2026.
+ * Status: Public Beta. Non-custodial, unaudited (no external audit completed or scheduled).
  */
 
 // Type-only: resolved from the host OpenClaw runtime at load time.

--- a/packages/openclaw-x402-pay/README.md
+++ b/packages/openclaw-x402-pay/README.md
@@ -1,6 +1,9 @@
 # openclaw-x402-pay — self-custody x402 payments for OpenClaw agents
 
-> 💜 [Star it on ClawHub](https://clawhub.ai/parad0x-labs/x402-pay) if it earns its keep.
+> ⚠️ **MOVED — this copy is frozen.** The canonical home of this skill is now
+> [openclaw-skills/skills/x402-pay](https://github.com/Parad0x-Labs/openclaw-skills/tree/main/skills/x402-pay).
+> Install from, file issues against, and contribute to openclaw-skills; this
+> directory remains only as a historical pointer and will not receive updates.
 
 Give your agent one tool — `pay_x402` — that fetches an x402-gated URL and, if it
 answers HTTP **402 Payment Required**, pays for it on Solana and returns the
@@ -20,8 +23,8 @@ resource. Pairs with [`openclaw-x402-gate`](https://github.com/Parad0x-Labs/dna-
 - **Minimal network surface.** Talks only to your configured Solana RPC and the
   target URL. No telemetry, no third-party calls.
 
-> **Status: Public Beta.** Non-custodial, capped, external audit scheduled Q3 2026.
-> **Not yet audited** — do not point it at large balances.
+> **Status: Public Beta.** Non-custodial, capped, **unaudited** — no external audit
+> has been completed or scheduled. Do not point it at large balances.
 
 ## Use it
 

--- a/packages/openclaw-x402-pay/SKILL.md
+++ b/packages/openclaw-x402-pay/SKILL.md
@@ -1,5 +1,9 @@
 # x402 Pay
 
+> ⚠️ **MOVED:** canonical home is
+> [openclaw-skills/skills/x402-pay](https://github.com/Parad0x-Labs/openclaw-skills/tree/main/skills/x402-pay).
+> This copy is frozen.
+
 Let your OpenClaw agent **pay for x402-gated APIs, data, and other agents** on
 Solana — without ever handing the skill a private key.
 
@@ -24,8 +28,8 @@ Solana — without ever handing the skill a private key.
 - **Hard `maxAmountUsdc` cap**, enforced before any transaction is built.
 - **Minimal network**: your Solana RPC + the target URL only. No telemetry.
 
-> **Public Beta** — non-custodial, capped, external audit scheduled Q3 2026.
-> Not yet audited; don't point it at large balances.
+> **Public Beta** — non-custodial, capped, **unaudited** (no external audit
+> completed or scheduled); don't point it at large balances.
 
 ## The tool
 

--- a/packages/openclaw-x402-pay/src/index.ts
+++ b/packages/openclaw-x402-pay/src/index.ts
@@ -15,8 +15,8 @@
  *   - NETWORK: talks only to the configured Solana RPC and the target URL.
  *     No telemetry, no third-party endpoints.
  *
- * Status: Public Beta. Non-custodial, capped, external audit scheduled Q3 2026.
- * Not yet audited — do not point it at large balances.
+ * Status: Public Beta. Non-custodial, capped, unaudited (no external audit
+ * completed or scheduled) — do not point it at large balances.
  */
 
 // Type-only import: resolved from the host OpenClaw runtime at load time, same


### PR DESCRIPTION
## What

The three OpenClaw skills (`x402-pay`, `x402-gate`, `context-capsule`) migrated to the claw-family skills monorepo — [openclaw-skills](https://github.com/Parad0x-Labs/openclaw-skills) (PR #32 there) — where each is a self-contained module: no cross-skill imports, standalone strict typecheck, path-filtered CI, and a claims-guard CI step.

This PR freezes the copies here:
- ⚠️ MOVED banners on all three READMEs + SKILL.mds pointing at the canonical `skills/<name>` homes
- Purges the forbidden **"external audit scheduled Q3 2026"** wording that still lived in these copies (READMEs, SKILL.mds, src headers) → "unaudited — no external audit completed or scheduled" per the 2026-06-08 claims rule

Code is intentionally left intact (frozen pointer, not deletion) until npm publishing flows from the new home.

## Test plan
- Docs/comments only — no behavior change; `grep -rn 'Q3 2026|audit scheduled'` clean across the three packages (one remaining hit in `packages/context-capsule/tests` is fictional fixture dialogue in the standalone core package, untouched)