### PR TITLE
fix(zk): route vk-mode to the ceremony zkey/vk the deployed pool embeds

### DIFF
--- a/build/zk/README.md
+++ b/build/zk/README.md
@@ -27,6 +27,15 @@ node init-buckets-devnet.mjs <PROGRAM_ID>     # 0.1 / 1 / 10 SOL denomination bu
 node e2e-v3-devnet.mjs <PROGRAM_ID>           # full relayer-fee e2e -> evidence/dark-relay-rail-devnet.json
 ```
 
+**VK mode.** `prove-v3.mjs` and the e2e/fusion scripts default to `--vk-mode ceremony`,
+which uses the beacon-sealed multi-contribution key under
+`ceremony/shielded_withdraw_v3/` — the VK the canonically deployed devnet program embeds
+(`crates/dark-groth16-core/src/shielded_withdraw_v3_vk.rs`, `alpha_g1.x=2d4d9aa7…`). The
+single-party **pilot** VK (`build/zk/out/shielded_withdraw_v3_vk.json`, `alpha_g1.x=2f881452…`)
+verifies locally but is **rejected on-chain with `Custom(4)=ProofInvalid`**, so `--vk-mode pilot`
+is refused by the e2e scripts. A pilot proof is only meaningful against a pool you built and
+deployed yourself with the pilot VK (set `SWV3_ZKEY`/`SWV3_VK` explicitly for that local case).
+
 Trustless VK (multi-party ceremony, public ptau + drand beacon):
 `node ceremony/run-ceremony-v3.mjs --contribs 3 --power 14` (see `ceremony/CONTRIBUTING_V3.md`).
 

--- a/build/zk/e2e-v3-devnet.mjs
+++ b/build/zk/e2e-v3-devnet.mjs
@@ -17,9 +17,10 @@
  * syscall against state the program built with the sol_poseidon syscall. The proof
  * binds relayer + fee, so the 2-way payout split is fixed by the proof.
  *
- * Usage: node build/zk/e2e-v3-devnet.mjs <PROGRAM_ID> [--vk-mode pilot|ceremony]
- *   --vk-mode ceremony : the program on-chain must already carry the ceremony VK; the
- *                        prover then uses SWV3_ZKEY/SWV3_VK env (ceremony zkey/vk).
+ * Usage: node build/zk/e2e-v3-devnet.mjs <PROGRAM_ID> [--vk-mode ceremony]
+ *   vk-mode=ceremony (default) : the prover uses the CEREMONY zkey/vk the deployed
+ *     program embeds (forwarded to prove-v3.mjs as SWV3_VK_MODE). The single-party
+ *     pilot VK is rejected on-chain (Custom(4)=ProofInvalid), so it is not supported.
  */
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync, existsSync } from "node:fs";
@@ -36,7 +37,18 @@ const REPO = join(HERE, "..", "..");
 const RPC = process.env.RPC ?? "https://api.devnet.solana.com";
 const CLUSTER = RPC.includes("mainnet") ? "mainnet-beta" : "devnet";
 const PROGRAM_ID = new PublicKey(process.argv[2]);
-const VK_MODE = (() => { const i = process.argv.indexOf("--vk-mode"); return i !== -1 ? process.argv[i + 1] : "pilot"; })();
+const VK_MODE = (() => { const i = process.argv.indexOf("--vk-mode"); return (i !== -1 ? process.argv[i + 1] : "ceremony").toLowerCase(); })();
+if (VK_MODE === "pilot") {
+  console.error(
+    "e2e-v3-devnet.mjs: --vk-mode pilot is not supported against the deployed pool.\n" +
+    "  The on-chain program embeds the CEREMONY verifying key; pilot (single-party) proofs\n" +
+    "  are rejected with Custom(4)=ProofInvalid. Re-run with --vk-mode ceremony (the default).");
+  process.exit(2);
+}
+if (VK_MODE !== "ceremony") {
+  console.error(`e2e-v3-devnet.mjs: unknown --vk-mode '${VK_MODE}' (only 'ceremony' is supported)`);
+  process.exit(2);
+}
 const DENOM = 100_000_000; // 0.1 SOL per note
 const FEE = 1_000_000;     // 0.001 SOL relayer reimbursement (<= MAX_FEE = 0.05 SOL)
 
@@ -187,7 +199,9 @@ function prove(spec, { fee = FEE, denom = DENOM, expectFail = false } = {}) {
   const sIn = join(tmp, "spec.json"), sOut = join(tmp, "out.json");
   writeFileSync(sIn, JSON.stringify({ ...spec, fee: String(fee), denomination: String(denom) }));
   try {
-    execFileSync(process.execPath, [join(HERE, "prove-v3.mjs"), sIn, sOut], { stdio: "pipe" });
+    // Forward vk-mode so the prover uses the CEREMONY zkey/vk the deployed program embeds.
+    execFileSync(process.execPath, [join(HERE, "prove-v3.mjs"), sIn, sOut],
+      { stdio: "pipe", env: { ...process.env, SWV3_VK_MODE: VK_MODE } });
   } catch (e) {
     rmSync(tmp, { recursive: true, force: true });
     if (expectFail) return { proofFailed: true, stderr: (e.stderr ?? Buffer.from("")).toString().slice(0, 200) };
@@ -363,9 +377,7 @@ async function main() {
     relayerFeeLamports: FEE,
     vkMode: VK_MODE,
     circuit: "shielded_withdraw_v3.circom (Poseidon commitment+nullifier, 20-level Poseidon Merkle, recipient+pool_id+relayer bound, in-proof fee: payout=denom-fee, fee<=MAX_FEE)",
-    vk: VK_MODE === "ceremony"
-      ? "shielded_withdraw_v3_vk (BEACON-SEALED MULTI-CONTRIBUTION CEREMONY, dry-run — public ptau + simulated-independent contributions + FIXED pre-committed drand beacon round 6000000; awaiting independent contributors, devnet pilot scope)"
-      : "shielded_withdraw_v3_vk (SINGLE-PARTY / DEVNET PILOT / NOT TRUSTLESS)",
+    vk: "shielded_withdraw_v3_vk (BEACON-SEALED MULTI-CONTRIBUTION CEREMONY, dry-run — public ptau + simulated-independent contributions + FIXED pre-committed drand beacon round 6000000; awaiting independent contributors, devnet pilot scope). This is the VK the deployed program embeds.",
     initSig,
     onChainRootAfterDeposits: rootAfter,
     coreCircuitRoot: rustRoot,
@@ -379,9 +391,7 @@ async function main() {
       "the withdraw and was reimbursed the proof-bound fee; the recipient received denom-fee " +
       "and never signed. Double-spend / wrong-root / wrong-recipient / over-fee / relayer-mismatch all reverted.",
     honestCaveats: [
-      VK_MODE === "ceremony"
-        ? "Ceremony VK is a BEACON-SEALED DRY RUN: multiple SIMULATED-independent phase-2 contributions (one machine, varied entropy) finalized with a FIXED, already-published drand beacon (round 6000000). The public beacon adds unpredictability nobody controls, but this is NOT yet fully trustless — real trustlessness needs the simulated contributors replaced by independent humans (see ceremony/CONTRIBUTING_V3.md). Claim: 'beacon-sealed multi-contribution ceremony (dry-run); awaiting independent contributors.'"
-        : "SINGLE-PARTY trusted setup — NOT trustless. Use --vk-mode ceremony for the beacon-sealed multi-contribution (dry-run) VK.",
+      "Ceremony VK is a BEACON-SEALED DRY RUN: multiple SIMULATED-independent phase-2 contributions (one machine, varied entropy) finalized with a FIXED, already-published drand beacon (round 6000000). The public beacon adds unpredictability nobody controls, but this is NOT yet fully trustless — real trustlessness needs the simulated contributors replaced by independent humans (see ceremony/CONTRIBUTING_V3.md). Claim: 'beacon-sealed multi-contribution ceremony (dry-run); awaiting independent contributors.'",
       "UNAUDITED devnet pilot. mainnet_ready=false throughout.",
       "Stealth recipient (NullPay) NOT integrated — recipient is a plain wallet here. Documented as a follow-up stub.",
       "Deposit binds leaf_index into the commitment, so the e2e requires a fresh pool (note_count==0) for deterministic Merkle-path rebuild.",

--- a/build/zk/fusion-e2e-devnet.mjs
+++ b/build/zk/fusion-e2e-devnet.mjs
@@ -29,14 +29,16 @@
  *
  * Honest scope (see also evidence honestCaveats):
  *   - UNAUDITED devnet pilot. mainnet_ready=false.
- *   - Trusted setup: pilot VK is SINGLE-PARTY (default); --vk-mode ceremony uses the
- *     beacon-sealed multi-contribution DRY-RUN VK (still awaiting independent humans).
+ *   - Trusted setup: this runs under the beacon-sealed multi-contribution DRY-RUN
+ *     ceremony VK (the one the deployed program embeds; still awaiting independent
+ *     humans). vk-mode=ceremony is the default and only supported mode here — the
+ *     single-party pilot VK is rejected on-chain (Custom(4)=ProofInvalid).
  *   - Single-party demo: sender, payee, relayer are all driven by this one script;
  *     the unlinkability is structural (what does / does not appear on-chain), not a
  *     claim that a real anonymity set exists in this 2-note pool.
  *
  * Usage:
- *   node build/zk/fusion-e2e-devnet.mjs <POOL_PROGRAM_ID> --registrar <REGISTRAR_ID> [--vk-mode pilot|ceremony]
+ *   node build/zk/fusion-e2e-devnet.mjs <POOL_PROGRAM_ID> --registrar <REGISTRAR_ID> [--vk-mode ceremony]
  */
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
@@ -58,7 +60,18 @@ const RPC = process.env.RPC ?? "https://api.devnet.solana.com";
 const CLUSTER = RPC.includes("mainnet") ? "mainnet-beta" : "devnet";
 const POOL_PROGRAM = new PublicKey(process.argv[2]);
 const REGISTRAR = new PublicKey(arg("registrar"));
-const VK_MODE = arg("vk-mode", "pilot");
+const VK_MODE = arg("vk-mode", "ceremony").toLowerCase();
+if (VK_MODE === "pilot") {
+  console.error(
+    "fusion-e2e-devnet.mjs: --vk-mode pilot is not supported against the deployed pool.\n" +
+    "  The on-chain program embeds the CEREMONY verifying key; pilot (single-party) proofs\n" +
+    "  are rejected with Custom(4)=ProofInvalid. Re-run with --vk-mode ceremony (the default).");
+  process.exit(2);
+}
+if (VK_MODE !== "ceremony") {
+  console.error(`fusion-e2e-devnet.mjs: unknown --vk-mode '${VK_MODE}' (only 'ceremony' is supported)`);
+  process.exit(2);
+}
 const DENOM = 100_000_000; // 0.1 SOL fixed denomination
 const FEE = 1_000_000;     // 0.001 SOL relayer reimbursement (<= MAX_FEE = 0.05 SOL)
 
@@ -192,7 +205,9 @@ function prove(spec, { fee = FEE, denom = DENOM } = {}) {
   const tmp = mkdtempSync(join(tmpdir(), "fuse-proof-"));
   const sIn = join(tmp, "spec.json"), sOut = join(tmp, "out.json");
   writeFileSync(sIn, JSON.stringify({ ...spec, fee: String(fee), denomination: String(denom) }));
-  execFileSync(process.execPath, [join(HERE, "prove-v3.mjs"), sIn, sOut], { stdio: "pipe" });
+  // Forward vk-mode so the prover uses the CEREMONY zkey/vk the deployed program embeds.
+  execFileSync(process.execPath, [join(HERE, "prove-v3.mjs"), sIn, sOut],
+    { stdio: "pipe", env: { ...process.env, SWV3_VK_MODE: VK_MODE } });
   const out = JSON.parse(readFileSync(sOut, "utf8"));
   rmSync(tmp, { recursive: true, force: true });
   return out;
@@ -526,9 +541,7 @@ async function main() {
   ev.poolVault = poolVault.toBase58();
   ev.onChainRootAfterDeposits = rootAfter;
   ev.circuit = "shielded_withdraw_v3.circom (Poseidon commitment+nullifier, 20-level Poseidon Merkle, recipient+pool_id+relayer bound, in-proof fee: payout=denom-fee, fee<=MAX_FEE)";
-  ev.vk = VK_MODE === "ceremony"
-    ? "shielded_withdraw_v3_vk (BEACON-SEALED MULTI-CONTRIBUTION CEREMONY, DRY-RUN — public ptau + simulated-independent contributions + FIXED pre-committed drand beacon; awaiting independent contributors, devnet pilot scope)"
-    : "shielded_withdraw_v3_vk (SINGLE-PARTY / DEVNET PILOT / NOT TRUSTLESS)";
+  ev.vk = "shielded_withdraw_v3_vk (BEACON-SEALED MULTI-CONTRIBUTION CEREMONY, DRY-RUN — public ptau + simulated-independent contributions + FIXED pre-committed drand beacon; awaiting independent contributors, devnet pilot scope). This is the VK the deployed program embeds.";
   ev.keystone =
     "ONE shielded-pool withdraw hides ALL THREE payment legs at once: (a) SENDER — a real Groth16 " +
     "membership proof (alt_bn128 pairing syscall) authorizes the spend with NO depositor signature/link " +
@@ -537,9 +550,7 @@ async function main() {
     "meta. A permissionless RELAYER submits it (fee_payer != P); P never signs; the payee view-key-scans, " +
     "recovers the one-time scalar p, and sweeps P natively. The payee's MAIN wallet never appears in the withdraw tx.";
   ev.honestCaveats = [
-    VK_MODE === "ceremony"
-      ? "Ceremony VK is a BEACON-SEALED DRY RUN (simulated-independent contributions + fixed published drand beacon). NOT yet fully trustless; needs independent human contributors (ceremony/CONTRIBUTING_V3.md)."
-      : "SINGLE-PARTY trusted setup — NOT trustless. Use --vk-mode ceremony for the beacon-sealed multi-contribution (dry-run) VK.",
+    "Ceremony VK is a BEACON-SEALED DRY RUN (simulated-independent contributions + fixed published drand beacon). NOT yet fully trustless; needs independent human contributors (ceremony/CONTRIBUTING_V3.md).",
     "UNAUDITED devnet pilot. mainnet_ready=false throughout. Library / demo only.",
     "SINGLE-PARTY demo: sender, payee, and relayer are all driven by this one script. The unlinkability is STRUCTURAL (what does / does not appear on-chain), not a claim of a large real anonymity set — this pool has only 2 notes.",
     "The .null domain is registered by our wallet (the publisher of the name); that publisher key is distinct from the payee's unlinkable MAIN wallet, which never touches the withdraw tx.",

--- a/build/zk/fusion-mayhem-devnet.mjs
+++ b/build/zk/fusion-mayhem-devnet.mjs
@@ -1,0 +1,659 @@
+#!/usr/bin/env node
+/**
+ * MAYHEM — adversarial hammering of the PRIVATE-RAIL FUSION flow (pool x stealth).
+ * DEVNET ONLY. Spins up its OWN fresh pool + fresh payee.null so it never touches
+ * the live demo's deployed config. Tests CROSS-RAIL SEAMS, not pool/registrar
+ * internals (covered by other lanes).
+ *
+ * Scenarios:
+ *   S1  tamper published ephemeral R -> payee scan must FAIL safely (no false match)
+ *   S2  derive a stealth P, but submit withdraw bound to a DIFFERENT P -> reject (ProofInvalid)
+ *   S3  replay the fused withdraw (same nullifier) -> reject (NullifierAlreadySpent)
+ *   S4  stealth meta that does NOT match the name -> sender derives P' from foreign meta;
+ *       real payee scan must NOT match it (payment is not theirs)
+ *   S5  payee MAIN wallet never enters the withdraw tx across N runs
+ *   S6  one-time addresses never repeat across payments (N derivations, all distinct)
+ *   S7  forged R in the withdraw memo while paying the REAL P -> withdraw still lands
+ *       (R is off-chain only) but payee scan of the forged R must FAIL -> funds
+ *       become unsweepable-by-scan (availability seam, documented)
+ *
+ * Usage: node build/zk/fusion-mayhem-devnet.mjs <POOL_PROGRAM_ID> --registrar <REGISTRAR_ID>
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { randomBytes, createHash, webcrypto as crypto } from "node:crypto";
+import {
+  Connection, Keypair, PublicKey, Transaction, TransactionInstruction,
+  SystemProgram, ComputeBudgetProgram, sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import nacl from "tweetnacl";
+import { keygen, derive, scan, recover } from "../../scripts/nullpay/nullpay-client.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, "..", "..");
+const arg = (n, d) => { const i = process.argv.indexOf("--" + n); return i !== -1 ? process.argv[i + 1] : d; };
+const RPC = process.env.RPC ?? "https://api.devnet.solana.com";
+if (RPC.includes("mainnet")) { console.error("REFUSING to run on mainnet"); process.exit(2); }
+const CLUSTER = "devnet";
+const POOL_PROGRAM = new PublicKey(process.argv[2]);
+const REGISTRAR = new PublicKey(arg("registrar"));
+const DENOM = 100_000_000;
+const FEE = 1_000_000;
+
+const conn = new Connection(RPC, "confirmed");
+const keyPath = execFileSync("solana", ["config", "get"], { encoding: "utf8" })
+  .match(/Keypair Path:\s+(.+)/)[1].trim();
+const wallet = Keypair.fromSecretKey(Uint8Array.from(JSON.parse(readFileSync(keyPath, "utf8"))));
+
+const authority = Keypair.generate();
+const SEEDS = {
+  config: Buffer.from("pool_config"), vault: Buffer.from("pool_vault"),
+  leaf: Buffer.from("note_leaf"), nullifier: Buffer.from("nullifier"),
+};
+const u64le = (n) => { const b = Buffer.alloc(8); b.writeBigUInt64LE(BigInt(n)); return b; };
+const [poolConfig] = PublicKey.findProgramAddressSync([SEEDS.config, authority.publicKey.toBuffer()], POOL_PROGRAM);
+const [poolVault] = PublicKey.findProgramAddressSync([SEEDS.vault, poolConfig.toBuffer()], POOL_PROGRAM);
+const noteLeafPda = (i) => PublicKey.findProgramAddressSync([SEEDS.leaf, poolConfig.toBuffer(), u64le(i)], POOL_PROGRAM)[0];
+const nullifierPda = (n) => PublicKey.findProgramAddressSync([SEEDS.nullifier, poolConfig.toBuffer(), Buffer.from(n, "hex")], POOL_PROGRAM)[0];
+
+const DOMAIN_SEED = Buffer.from("null-domain");
+const REGISTRY_SEED = Buffer.from("null-registry");
+const IX_INIT_REGISTRY = 0x01, IX_REGISTER = 0x02, IX_SET_STEALTH_META = 0x06;
+const ND_OFF_STEALTH_META = 154;
+const MEMO_PROGRAM_ID = new PublicKey("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");
+const SYS = SystemProgram.programId;
+const sysAccount = { pubkey: SYS, isSigner: false, isWritable: false };
+const cuIx = (units) => ComputeBudgetProgram.setComputeUnitLimit({ units });
+const pad64 = (name) => { const b = Buffer.alloc(64); Buffer.from(name, "utf8").copy(b); return b; };
+
+async function send(ixs, signers, feePayer, label, { expectFail = false } = {}) {
+  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("confirmed");
+  const tx = new Transaction({ blockhash, lastValidBlockHeight, feePayer });
+  for (const ix of ixs) tx.add(ix);
+  tx.sign(...signers);
+  let sig;
+  try {
+    sig = await conn.sendRawTransaction(tx.serialize(), { skipPreflight: true });
+    await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
+  } catch (e) {
+    if (expectFail) { return { executed: false, sig: e.signature ?? null, err: e.message, logs: [] }; }
+    console.error(`  [${label}] send FAILED: ${e.message?.slice(0, 200)}`); throw e;
+  }
+  let meta = null;
+  for (let attempt = 0; attempt < 10 && !meta; attempt++) {
+    const t = await conn.getTransaction(sig, { commitment: "confirmed", maxSupportedTransactionVersion: 0 });
+    if (t?.meta) meta = t.meta; else await new Promise((r) => setTimeout(r, 800));
+  }
+  const err = meta?.err ?? null;
+  const executed = err === null;
+  const logs = meta?.logMessages ?? [];
+  return { executed, sig, err, logs };
+}
+
+function customCode(logs, err) {
+  // pull "custom program error: 0xN" or {"Custom":N}
+  for (const l of logs ?? []) {
+    const m = l.match(/custom program error:\s*0x([0-9a-fA-F]+)/);
+    if (m) return parseInt(m[1], 16);
+  }
+  if (err && typeof err === "object") {
+    const ie = err.InstructionError;
+    if (Array.isArray(ie) && ie[1] && typeof ie[1] === "object" && "Custom" in ie[1]) return ie[1].Custom;
+  }
+  return null;
+}
+function errName(logs, err) {
+  const c = customCode(logs, err);
+  const names = {
+    0: "AlreadyInitialized", 1: "PoolPaused", 2: "ZeroCommitment", 3: "NullifierAlreadySpent",
+    4: "ProofInvalid", 5: "ZeroDenomination", 6: "InsufficientFunds", 7: "NotInitialized",
+    8: "InvalidInstruction", 9: "ArithmeticOverflow", 10: "StubNotReady", 11: "BelowMinimumDeposit",
+    12: "UnknownRoot", 13: "FeeExceedsDenomination",
+  };
+  if (c !== null) return `Custom(${c})=${names[c] ?? "?"}`;
+  if (err && typeof err === "object" && err.InstructionError) {
+    const ie = err.InstructionError;
+    if (typeof ie[1] === "string") return ie[1]; // e.g. "InvalidArgument", "MissingRequiredSignature"
+  }
+  return JSON.stringify(err);
+}
+
+const initIx = () => new TransactionInstruction({
+  programId: POOL_PROGRAM,
+  keys: [
+    { pubkey: poolConfig, isSigner: false, isWritable: true },
+    { pubkey: poolVault, isSigner: false, isWritable: true },
+    { pubkey: authority.publicKey, isSigner: true, isWritable: true },
+    sysAccount,
+  ],
+  data: Buffer.concat([Buffer.from([0x00]), u64le(DENOM)]),
+});
+const depositIx = (leafIndex, commitmentHex) => new TransactionInstruction({
+  programId: POOL_PROGRAM,
+  keys: [
+    { pubkey: poolConfig, isSigner: false, isWritable: true },
+    { pubkey: poolVault, isSigner: false, isWritable: true },
+    { pubkey: noteLeafPda(leafIndex), isSigner: false, isWritable: true },
+    { pubkey: authority.publicKey, isSigner: true, isWritable: true },
+    sysAccount,
+  ],
+  data: Buffer.concat([Buffer.from([0x01]), Buffer.from(commitmentHex, "hex")]),
+});
+const withdrawIx = (nullifierHex, rootHex, proofHex, recipient, relayer, fee, recipientAccount) =>
+  new TransactionInstruction({
+    programId: POOL_PROGRAM,
+    keys: [
+      { pubkey: poolConfig, isSigner: false, isWritable: true },
+      { pubkey: poolVault, isSigner: false, isWritable: true },
+      { pubkey: nullifierPda(nullifierHex), isSigner: false, isWritable: true },
+      { pubkey: recipientAccount ?? recipient, isSigner: false, isWritable: true },
+      { pubkey: relayer, isSigner: true, isWritable: true },
+      sysAccount,
+    ],
+    data: Buffer.concat([
+      Buffer.from([0x02]), Buffer.from(nullifierHex, "hex"), Buffer.from(rootHex, "hex"),
+      Buffer.from(proofHex, "hex"), recipient.toBuffer(), relayer.toBuffer(), u64le(fee),
+    ]),
+  });
+
+async function readRoot() {
+  const ai = await conn.getAccountInfo(poolConfig, "confirmed");
+  return Buffer.from(ai.data.slice(44, 76)).toString("hex");
+}
+async function readNoteCount() {
+  const ai = await conn.getAccountInfo(poolConfig, "confirmed");
+  return Number(Buffer.from(ai.data.slice(76, 84)).readBigUInt64LE());
+}
+
+function genSecretHex() { const b = Buffer.from(crypto.getRandomValues(new Uint8Array(32))); b[0] = 0x05; return b.toString("hex"); }
+function witnessSpec(scenario) {
+  const tmp = mkdtempSync(join(tmpdir(), "mh-"));
+  const sIn = join(tmp, "scenario.json"), sOut = join(tmp, "spec.json");
+  writeFileSync(sIn, JSON.stringify(scenario));
+  execFileSync("cargo", ["run", "-q", "-p", "dark-shielded-pool-core", "--bin", "witness_spec",
+    "--features", "witness-gen", "--", sIn, sOut], { cwd: REPO, stdio: "pipe" });
+  const spec = JSON.parse(readFileSync(sOut, "utf8"));
+  rmSync(tmp, { recursive: true, force: true });
+  return spec;
+}
+function prove(spec, { fee = FEE, denom = DENOM } = {}) {
+  const tmp = mkdtempSync(join(tmpdir(), "mh-proof-"));
+  const sIn = join(tmp, "spec.json"), sOut = join(tmp, "out.json");
+  writeFileSync(sIn, JSON.stringify({ ...spec, fee: String(fee), denomination: String(denom) }));
+  // Mayhem lands REAL fused withdraws against the deployed pool (S3 replay, S5/S7),
+  // which embeds the CEREMONY VK — so proofs MUST be ceremony (pilot => Custom(4) ProofInvalid).
+  execFileSync(process.execPath, [join(HERE, "prove-v3.mjs"), sIn, sOut],
+    { stdio: "pipe", env: { ...process.env, SWV3_VK_MODE: "ceremony" } });
+  const out = JSON.parse(readFileSync(sOut, "utf8"));
+  rmSync(tmp, { recursive: true, force: true });
+  return out;
+}
+
+const results = { scenarios: [], held: [], broke: [] };
+const hold = (name, expected, detail) => { results.held.push({ name, expected, ...detail }); console.log(`  HELD: ${name} — ${expected}`); };
+const broke = (name, what, severity, evidence) => { results.broke.push({ name, what, severity, evidence }); console.log(`  *** BROKE [${severity}]: ${name} — ${what} (${evidence})`); };
+
+async function registrarSend(ixs, signers) {
+  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("confirmed");
+  const tx = new Transaction({ blockhash, lastValidBlockHeight, feePayer: wallet.publicKey });
+  ixs.forEach((i) => tx.add(i));
+  return await sendAndConfirmTransaction(conn, tx, signers, { commitment: "confirmed" });
+}
+
+async function registerPayee(prefix) {
+  const spendSeed = randomBytes(32);
+  const keys = keygen(spendSeed);
+  const mainWallet = Keypair.generate();
+  const NAME = prefix + Date.now().toString(36).slice(-6) + Math.floor(Math.random() * 1e3);
+  const nameSeed = Buffer.from(NAME, "utf8");
+  const [configPDA] = PublicKey.findProgramAddressSync([REGISTRY_SEED], REGISTRAR);
+  const [domainPDA] = PublicKey.findProgramAddressSync([DOMAIN_SEED, nameSeed], REGISTRAR);
+
+  const cfgInfo = await conn.getAccountInfo(configPDA);
+  if (!cfgInfo) {
+    const data = Buffer.alloc(1 + 8 + 32 + 32);
+    data.writeUInt8(IX_INIT_REGISTRY, 0); data.writeBigUInt64LE(0n, 1);
+    wallet.publicKey.toBuffer().copy(data, 9); wallet.publicKey.toBuffer().copy(data, 41);
+    const ix = new TransactionInstruction({ programId: REGISTRAR, keys: [
+      { pubkey: wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: configPDA, isSigner: false, isWritable: true },
+      { pubkey: SYS, isSigner: false, isWritable: false },
+    ], data });
+    await registrarSend([ix], [wallet]);
+  }
+  {
+    const contentHash = createHash("sha256").update(`${NAME}.null:mayhem`).digest();
+    const data = Buffer.alloc(1 + 64 + 32);
+    data.writeUInt8(IX_REGISTER, 0); pad64(NAME).copy(data, 1); contentHash.copy(data, 65);
+    const ix = new TransactionInstruction({ programId: REGISTRAR, keys: [
+      { pubkey: wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: domainPDA, isSigner: false, isWritable: true },
+      { pubkey: configPDA, isSigner: false, isWritable: true },
+      { pubkey: wallet.publicKey, isSigner: false, isWritable: false },
+      { pubkey: wallet.publicKey, isSigner: false, isWritable: false },
+      { pubkey: SYS, isSigner: false, isWritable: false },
+    ], data });
+    await registrarSend([ix], [wallet]);
+  }
+  {
+    const data = Buffer.alloc(1 + 64 + 64);
+    data.writeUInt8(IX_SET_STEALTH_META, 0); pad64(NAME).copy(data, 1);
+    Buffer.from(keys.meta).copy(data, 65);
+    const ix = new TransactionInstruction({ programId: REGISTRAR, keys: [
+      { pubkey: wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: domainPDA, isSigner: false, isWritable: true },
+      { pubkey: SYS, isSigner: false, isWritable: false },
+    ], data });
+    await registrarSend([ix], [wallet]);
+  }
+  return { keys, mainWallet, NAME, domainPDA };
+}
+
+async function readMeta(domainPDA) {
+  const info = await conn.getAccountInfo(domainPDA, "confirmed");
+  if (!info || info.data.length < ND_OFF_STEALTH_META + 64) throw new Error("domain not v2-sized");
+  return Uint8Array.from(info.data.subarray(ND_OFF_STEALTH_META, ND_OFF_STEALTH_META + 64));
+}
+
+async function main() {
+  console.log(`\n=== FUSION MAYHEM (DEVNET) ===`);
+  console.log(`pool      ${POOL_PROGRAM.toBase58()}`);
+  console.log(`registrar ${REGISTRAR.toBase58()}`);
+  console.log(`authority ${authority.publicKey.toBase58()} (fresh pool)`);
+
+  // ---- PART A: register the REAL payee + a FOREIGN payee (for S4) ----
+  console.log(`\n[setup] register real payee + foreign payee`);
+  const payee = await registerPayee("mhpay");
+  const foreign = await registerPayee("mhfgn");
+  console.log(`  real payee     ${payee.NAME}.null  domain ${payee.domainPDA.toBase58()}`);
+  console.log(`  foreign payee  ${foreign.NAME}.null domain ${foreign.domainPDA.toBase58()}`);
+
+  // ---- PART B: fresh pool + relayer funding + 2 deposits ----
+  const relayer = Keypair.generate();
+  {
+    const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("confirmed");
+    const tx = new Transaction({ blockhash, lastValidBlockHeight, feePayer: wallet.publicKey })
+      .add(SystemProgram.transfer({ fromPubkey: wallet.publicKey, toPubkey: authority.publicKey, lamports: 1_000_000_000 }))
+      .add(SystemProgram.transfer({ fromPubkey: wallet.publicKey, toPubkey: relayer.publicKey, lamports: 300_000_000 }));
+    tx.sign(wallet);
+    const sig = await conn.sendRawTransaction(tx.serialize(), { skipPreflight: true });
+    await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
+  }
+  await send([initIx()], [authority], authority.publicKey, "init");
+  const base = await readNoteCount();
+  if (base !== 0) throw new Error(`fresh pool expected note_count 0, got ${base}`);
+
+  const poolKeyHex = Buffer.from(poolConfig.toBytes()).toString("hex");
+  const relayerHex = Buffer.from(relayer.publicKey.toBytes()).toString("hex");
+  const sA = genSecretHex(), sB = genSecretHex();
+  const specForCommits = witnessSpec({ poolKeyHex, recipientHex: "05" + "00".repeat(31), relayerHex, spendIndex: 1, secretsHex: [sA, sB] });
+  const commits = specForCommits.commitmentsHex;
+  await send([cuIx(400_000), depositIx(0, commits[0])], [authority], authority.publicKey, "deposit#0");
+  await send([cuIx(400_000), depositIx(1, commits[1])], [authority], authority.publicKey, "deposit#1");
+  const rootAfter = await readRoot();
+  console.log(`  pool root after 2 deposits ${rootAfter}`);
+
+  // ---- resolve real payee meta, derive the legit one-time P (spendIndex 1) ----
+  const meta = await readMeta(payee.domainPDA);
+  if (Buffer.compare(Buffer.from(meta), Buffer.from(payee.keys.meta)) !== 0) {
+    broke("meta_roundtrip", "on-chain meta != published meta", "high", "registrar stored wrong bytes");
+  } else hold("S0_meta_roundtrip", "on-chain meta == published payee meta");
+
+  const ephemSeed = randomBytes(32);
+  const payment = derive(meta, ephemSeed);
+  const P = new PublicKey(payment.stealthPub);
+  const ephemHex = Buffer.from(payment.ephemPub).toString("hex");
+  const recipientHex = Buffer.from(payment.stealthPub).toString("hex");
+  console.log(`  legit P ${P.toBase58()}  R ${ephemHex.slice(0, 16)}…`);
+
+  // build the legit proof bound to P (note #1)
+  const spec = witnessSpec({ poolKeyHex, recipientHex, relayerHex, spendIndex: 1, secretsHex: [sA, sB] });
+  if (spec.expected.rootHex !== rootAfter) throw new Error("rust root != chain root");
+  const proof = prove(spec);
+  const nullifierHex = proof.publicInputsHex.nullifier;
+
+  // ════════════════════════════════════════════════════════════════════════
+  // S2 — BINDING: submit the (valid, P-bound) proof but pay a DIFFERENT P'.
+  // Derive an independent stealth P' from the SAME meta (different ephem).
+  // ════════════════════════════════════════════════════════════════════════
+  console.log(`\n[S2] valid proof bound to P, but submit paying a DIFFERENT stealth P'`);
+  const payment2 = derive(meta, randomBytes(32));
+  const Pprime = new PublicKey(payment2.stealthPub);
+  // recipient field in ix = P' (so processor's `recipient == recipient_info.key` passes),
+  // but the PROOF was generated binding recipient = P. Proof verify must reject.
+  const s2 = await send(
+    [cuIx(1_400_000), withdrawIx(nullifierHex, rootAfter, proof.proof256Hex, Pprime, relayer.publicKey, FEE, Pprime)],
+    [relayer], relayer.publicKey, "S2-wrong-P", { expectFail: true });
+  results.scenarios.push("S2_withdraw_bound_to_different_P");
+  if (s2.executed) {
+    broke("S2_binding_to_P", "withdraw paying a DIFFERENT stealth P' than the proof bound was ACCEPTED", "critical", `sig=${s2.sig}`);
+  } else {
+    const code = customCode(s2.logs, s2.err);
+    if (code === 4) hold("S2_binding_to_P", "rejected ProofInvalid (recipient binding holds)", { sig: s2.sig });
+    else { hold("S2_binding_to_P", `rejected (binding holds) but with ${errName(s2.logs, s2.err)} not ProofInvalid`, { sig: s2.sig });
+      broke("S2_binding_wrong_code", `rejected but with ${errName(s2.logs, s2.err)} instead of ProofInvalid(4)`, "low", `sig=${s2.sig}`); }
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // Now land the LEGIT fused withdraw to P (needed for replay + scan tests).
+  // ════════════════════════════════════════════════════════════════════════
+  console.log(`\n[legit] land the fused withdraw to the real P (relayer submits; P never signs)`);
+  const announce = `nullpay:v1:${payee.NAME}.null:R=${ephemHex}`;
+  const memoIx = new TransactionInstruction({ programId: MEMO_PROGRAM_ID, keys: [], data: Buffer.from(announce, "utf8") });
+  const pBefore = await conn.getBalance(P, "confirmed");
+  const w = await send(
+    [cuIx(1_400_000), withdrawIx(nullifierHex, rootAfter, proof.proof256Hex, P, relayer.publicKey, FEE), memoIx],
+    [relayer], relayer.publicKey, "legit-withdraw");
+  if (!w.executed) throw new Error(`legit withdraw failed: ${errName(w.logs, w.err)} sig=${w.sig}`);
+  const pAfter = await conn.getBalance(P, "confirmed");
+  console.log(`  legit withdraw ${w.sig}  P delta=${pAfter - pBefore} (expect ${DENOM - FEE})`);
+
+  // confirm payee main wallet absent in withdraw tx (single-run check; multi-run is S5)
+  const wTx = await conn.getTransaction(w.sig, { commitment: "confirmed", maxSupportedTransactionVersion: 0 });
+  const wAccounts = wTx.transaction.message.staticAccountKeys?.map((k) => k.toBase58())
+    || wTx.transaction.message.accountKeys.map((k) => k.toBase58());
+
+  // ════════════════════════════════════════════════════════════════════════
+  // S3 — REPLAY: resend the exact same fused withdraw (same nullifier).
+  // ════════════════════════════════════════════════════════════════════════
+  console.log(`\n[S3] replay the fused withdraw (same nullifier) -> expect NullifierAlreadySpent`);
+  const s3 = await send(
+    [cuIx(1_400_000), withdrawIx(nullifierHex, rootAfter, proof.proof256Hex, P, relayer.publicKey, FEE)],
+    [relayer], relayer.publicKey, "S3-replay", { expectFail: true });
+  results.scenarios.push("S3_replay_fused_withdraw");
+  if (s3.executed) {
+    broke("S3_replay", "replayed fused withdraw with same nullifier was ACCEPTED (double-spend)", "critical", `sig=${s3.sig}`);
+  } else {
+    const code = customCode(s3.logs, s3.err);
+    if (code === 3) hold("S3_replay", "rejected NullifierAlreadySpent", { sig: s3.sig });
+    else { hold("S3_replay", `rejected but with ${errName(s3.logs, s3.err)} not NullifierAlreadySpent`, { sig: s3.sig });
+      broke("S3_replay_wrong_code", `rejected but ${errName(s3.logs, s3.err)} instead of NullifierAlreadySpent(3)`, "low", `sig=${s3.sig}`); }
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // S1 — TAMPER R: flip bytes in the published ephemeral R. Payee scan must
+  //   either fail to find the point (invalid encoding) or NOT match (wrong R).
+  //   A tampered R must NEVER cause a false-positive match on the real P.
+  // ════════════════════════════════════════════════════════════════════════
+  console.log(`\n[S1] tamper the published ephemeral R -> payee scan must fail safely`);
+  results.scenarios.push("S1_tamper_ephemeral_R");
+  let s1FalseMatch = false, s1Errors = 0, s1Rejected = 0, s1Total = 0;
+  for (let t = 0; t < 6; t++) {
+    const bad = Buffer.from(payment.ephemPub);
+    // flip a random bit
+    const idx = Math.floor(Math.random() * 32);
+    bad[idx] ^= (1 << (Math.floor(Math.random() * 8)));
+    s1Total++;
+    let matched = false, threw = false;
+    try {
+      matched = scan(payee.keys, { stealthPub: payment.stealthPub, ephemPub: Uint8Array.from(bad) });
+    } catch (e) { threw = true; s1Errors++; }
+    if (matched) { s1FalseMatch = true; }
+    else if (!threw) s1Rejected++;
+  }
+  // also: zeroed R, all-ones R
+  for (const bad of [Buffer.alloc(32, 0), Buffer.alloc(32, 0xff)]) {
+    s1Total++;
+    try {
+      if (scan(payee.keys, { stealthPub: payment.stealthPub, ephemPub: Uint8Array.from(bad) })) s1FalseMatch = true;
+      else s1Rejected++;
+    } catch { s1Errors++; }
+  }
+  if (s1FalseMatch) {
+    broke("S1_tamper_R", "a TAMPERED ephemeral R produced a FALSE-POSITIVE scan match on the real P", "high", `${s1Total} mutations`);
+  } else {
+    hold("S1_tamper_R", `all ${s1Total} tampered R mutations -> no false match (${s1Rejected} clean reject, ${s1Errors} invalid-point reject)`);
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // S4 — WRONG META: sender derives P' from the FOREIGN payee's meta. The REAL
+  //   payee must NOT scan-match it (the payment is not theirs); and the foreign
+  //   payee SHOULD match it (sanity: meta really is foreign's).
+  // ════════════════════════════════════════════════════════════════════════
+  console.log(`\n[S4] derive payment from FOREIGN meta -> real payee must NOT match`);
+  results.scenarios.push("S4_stealth_meta_not_matching_name");
+  const foreignMeta = await readMeta(foreign.domainPDA);
+  const foreignPayment = derive(foreignMeta, randomBytes(32));
+  const realScansForeign = scan(payee.keys, foreignPayment);
+  const foreignScansForeign = scan(foreign.keys, foreignPayment);
+  if (realScansForeign) {
+    broke("S4_meta_crosslink", "REAL payee view-key matched a payment derived from a DIFFERENT name's meta", "high", "cross-identity false match");
+  } else if (!foreignScansForeign) {
+    broke("S4_meta_sanity", "foreign payee could not scan its own foreign-meta payment", "medium", "scan logic inconsistent");
+  } else {
+    hold("S4_meta_not_matching", "real payee does NOT match foreign-meta payment; foreign payee does (no cross-identity link)");
+  }
+  // also: tamper the meta itself (flip a byte) then derive -> real payee must not match
+  const tamperedMeta = Buffer.from(meta); tamperedMeta[0] ^= 0x01;
+  let tamperDeriveMatched = false, tamperThrew = false;
+  try {
+    const tp = derive(Uint8Array.from(tamperedMeta), randomBytes(32));
+    tamperDeriveMatched = scan(payee.keys, tp);
+  } catch { tamperThrew = true; }
+  if (tamperDeriveMatched) broke("S4_tampered_meta_match", "payment from a 1-byte-tampered meta still matched the real payee", "high", "spend_pub tamper not isolating");
+  else hold("S4_tampered_meta", tamperThrew ? "tampered meta -> invalid point (reject)" : "tampered meta -> no real-payee match");
+
+  // ════════════════════════════════════════════════════════════════════════
+  // S6 — ONE-TIME UNIQUENESS: derive N stealth addresses from the SAME meta;
+  //   all P and all R must be DISTINCT (no reuse across payments).
+  // ════════════════════════════════════════════════════════════════════════
+  console.log(`\n[S6] one-time address uniqueness across N derivations`);
+  results.scenarios.push("S6_one_time_addresses_never_repeat");
+  const N = 64;
+  const seenP = new Set(), seenR = new Set();
+  let dupP = 0, dupR = 0, scanFail = 0;
+  for (let i = 0; i < N; i++) {
+    const pm = derive(meta, randomBytes(32));
+    const ph = Buffer.from(pm.stealthPub).toString("hex");
+    const rh = Buffer.from(pm.ephemPub).toString("hex");
+    if (seenP.has(ph)) dupP++; seenP.add(ph);
+    if (seenR.has(rh)) dupR++; seenR.add(rh);
+    if (!scan(payee.keys, pm)) scanFail++; // every legit derivation must scan-match
+  }
+  if (dupP > 0 || dupR > 0) {
+    broke("S6_address_reuse", `one-time addresses REPEATED across payments (dupP=${dupP} dupR=${dupR})`, "high", `${N} derivations`);
+  } else if (scanFail > 0) {
+    broke("S6_scan_consistency", `${scanFail}/${N} legit derivations failed to scan-match the payee`, "medium", "derive/scan asymmetry");
+  } else {
+    hold("S6_one_time_uniqueness", `${N} derivations: all P distinct, all R distinct, all scan-match the payee`);
+  }
+
+  // ════════════════════════════════════════════════════════════════════════
+  // S5 — MAIN-WALLET ABSENCE across several independent fused payments. For
+  //   each run we derive a NEW P, prove note (alternating index), land the
+  //   withdraw, and assert the payee MAIN wallet never appears in the tx, the
+  //   sender wallet/authority never appear, and P appears exactly as recipient.
+  //   (We already spent note #1 above; spend note #0 here for run #1, and for
+  //   additional runs we use fresh pools to get more notes.)
+  // ════════════════════════════════════════════════════════════════════════
+  console.log(`\n[S5] payee MAIN wallet never enters the withdraw tx across runs`);
+  results.scenarios.push("S5_main_wallet_never_in_withdraw");
+  const runAccts = [];
+  // Run on note #0 of THIS pool.
+  {
+    const pm = derive(meta, randomBytes(32));
+    const P0 = new PublicKey(pm.stealthPub);
+    const rHex = Buffer.from(pm.stealthPub).toString("hex");
+    const spec0 = witnessSpec({ poolKeyHex, recipientHex: rHex, relayerHex, spendIndex: 0, secretsHex: [sA, sB] });
+    const proof0 = prove(spec0);
+    const ann0 = `nullpay:v1:${payee.NAME}.null:R=${Buffer.from(pm.ephemPub).toString("hex")}`;
+    const m0 = new TransactionInstruction({ programId: MEMO_PROGRAM_ID, keys: [], data: Buffer.from(ann0, "utf8") });
+    const r0 = await send(
+      [cuIx(1_400_000), withdrawIx(proof0.publicInputsHex.nullifier, rootAfter, proof0.proof256Hex, P0, relayer.publicKey, FEE), m0],
+      [relayer], relayer.publicKey, "S5-run0");
+    if (!r0.executed) { broke("S5_run0_failed", `run0 withdraw failed: ${errName(r0.logs, r0.err)}`, "medium", `sig=${r0.sig}`); }
+    else {
+      const t0 = await conn.getTransaction(r0.sig, { commitment: "confirmed", maxSupportedTransactionVersion: 0 });
+      const a0 = t0.transaction.message.staticAccountKeys?.map((k) => k.toBase58())
+        || t0.transaction.message.accountKeys.map((k) => k.toBase58());
+      runAccts.push({ sig: r0.sig, accts: a0, P: P0.toBase58() });
+    }
+  }
+
+  // Two more runs on a SECOND fresh pool (so we have several independent runs).
+  // (re-use the same payee identity; new pool => new notes.)
+  // Build a fresh pool inline.
+  async function freshPoolRun(label) {
+    const auth2 = Keypair.generate();
+    const [cfg2] = PublicKey.findProgramAddressSync([SEEDS.config, auth2.publicKey.toBuffer()], POOL_PROGRAM);
+    const [vault2] = PublicKey.findProgramAddressSync([SEEDS.vault, cfg2.toBuffer()], POOL_PROGRAM);
+    const leaf2 = (i) => PublicKey.findProgramAddressSync([SEEDS.leaf, cfg2.toBuffer(), u64le(i)], POOL_PROGRAM)[0];
+    const nul2 = (n) => PublicKey.findProgramAddressSync([SEEDS.nullifier, cfg2.toBuffer(), Buffer.from(n, "hex")], POOL_PROGRAM)[0];
+    {
+      const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("confirmed");
+      const tx = new Transaction({ blockhash, lastValidBlockHeight, feePayer: wallet.publicKey })
+        .add(SystemProgram.transfer({ fromPubkey: wallet.publicKey, toPubkey: auth2.publicKey, lamports: 600_000_000 }));
+      tx.sign(wallet);
+      const sig = await conn.sendRawTransaction(tx.serialize(), { skipPreflight: true });
+      await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
+    }
+    const init2 = new TransactionInstruction({ programId: POOL_PROGRAM, keys: [
+      { pubkey: cfg2, isSigner: false, isWritable: true }, { pubkey: vault2, isSigner: false, isWritable: true },
+      { pubkey: auth2.publicKey, isSigner: true, isWritable: true }, sysAccount,
+    ], data: Buffer.concat([Buffer.from([0x00]), u64le(DENOM)]) });
+    await send([init2], [auth2], auth2.publicKey, `${label}-init`);
+    const pk2 = Buffer.from(cfg2.toBytes()).toString("hex");
+    const c2A = genSecretHex(), c2B = genSecretHex();
+    const sc = witnessSpec({ poolKeyHex: pk2, recipientHex: "05" + "00".repeat(31), relayerHex, spendIndex: 0, secretsHex: [c2A, c2B] });
+    for (let i = 0; i < 2; i++) {
+      const dep = new TransactionInstruction({ programId: POOL_PROGRAM, keys: [
+        { pubkey: cfg2, isSigner: false, isWritable: true }, { pubkey: vault2, isSigner: false, isWritable: true },
+        { pubkey: leaf2(i), isSigner: false, isWritable: true }, { pubkey: auth2.publicKey, isSigner: true, isWritable: true }, sysAccount,
+      ], data: Buffer.concat([Buffer.from([0x01]), Buffer.from(sc.commitmentsHex[i], "hex")]) });
+      await send([cuIx(400_000), dep], [auth2], auth2.publicKey, `${label}-dep${i}`);
+    }
+    const ai = await conn.getAccountInfo(cfg2, "confirmed");
+    const root2 = Buffer.from(ai.data.slice(44, 76)).toString("hex");
+    const pm = derive(meta, randomBytes(32));
+    const Pn = new PublicKey(pm.stealthPub);
+    const sp = witnessSpec({ poolKeyHex: pk2, recipientHex: Buffer.from(pm.stealthPub).toString("hex"), relayerHex, spendIndex: 0, secretsHex: [c2A, c2B] });
+    const pr = prove(sp);
+    const wIx = new TransactionInstruction({ programId: POOL_PROGRAM, keys: [
+      { pubkey: cfg2, isSigner: false, isWritable: true }, { pubkey: vault2, isSigner: false, isWritable: true },
+      { pubkey: nul2(pr.publicInputsHex.nullifier), isSigner: false, isWritable: true },
+      { pubkey: Pn, isSigner: false, isWritable: true }, { pubkey: relayer.publicKey, isSigner: true, isWritable: true }, sysAccount,
+    ], data: Buffer.concat([Buffer.from([0x02]), Buffer.from(pr.publicInputsHex.nullifier, "hex"), Buffer.from(root2, "hex"),
+      Buffer.from(pr.proof256Hex, "hex"), Pn.toBuffer(), relayer.publicKey.toBuffer(), u64le(FEE)]) });
+    const ann = `nullpay:v1:${payee.NAME}.null:R=${Buffer.from(pm.ephemPub).toString("hex")}`;
+    const mIx = new TransactionInstruction({ programId: MEMO_PROGRAM_ID, keys: [], data: Buffer.from(ann, "utf8") });
+    const r = await send([cuIx(1_400_000), wIx, mIx], [relayer], relayer.publicKey, label);
+    if (!r.executed) { broke(`${label}_failed`, `withdraw failed: ${errName(r.logs, r.err)}`, "medium", `sig=${r.sig}`); return; }
+    const t = await conn.getTransaction(r.sig, { commitment: "confirmed", maxSupportedTransactionVersion: 0 });
+    const a = t.transaction.message.staticAccountKeys?.map((k) => k.toBase58())
+      || t.transaction.message.accountKeys.map((k) => k.toBase58());
+    runAccts.push({ sig: r.sig, accts: a, P: Pn.toBase58() });
+  }
+  await freshPoolRun("S5-run1");
+  await freshPoolRun("S5-run2");
+
+  // also include the first legit withdraw
+  runAccts.unshift({ sig: w.sig, accts: wAccounts, P: P.toBase58() });
+
+  const payeeMainB58 = payee.mainWallet.publicKey.toBase58();
+  const senderB58 = wallet.publicKey.toBase58();
+  const authB58 = authority.publicKey.toBase58();
+  let mainLeak = 0, senderLeak = 0, pMissing = 0, repeatP = 0;
+  const allP = new Set();
+  for (const r of runAccts) {
+    if (r.accts.includes(payeeMainB58)) mainLeak++;
+    if (r.accts.includes(senderB58) || r.accts.includes(authB58)) senderLeak++;
+    if (!r.accts.includes(r.P)) pMissing++;
+    if (allP.has(r.P)) repeatP++; allP.add(r.P);
+  }
+  console.log(`  runs=${runAccts.length} mainLeak=${mainLeak} senderLeak=${senderLeak} pMissing=${pMissing} repeatP=${repeatP}`);
+  if (mainLeak > 0) {
+    broke("S5_main_wallet_leak", `payee MAIN wallet appeared in ${mainLeak}/${runAccts.length} withdraw txs`, "high", runAccts.map((r) => r.sig).join(","));
+  } else {
+    hold("S5_main_absent", `payee main wallet absent from all ${runAccts.length} withdraw txs; P present as recipient in each; no P reused on-chain`);
+  }
+  if (senderLeak > 0) broke("S5_sender_leak", `sender/authority appeared in ${senderLeak}/${runAccts.length} withdraw txs`, "high", "sender-unlinkability seam");
+  else hold("S5_sender_absent", `sender wallet + depositor authority absent from all ${runAccts.length} withdraw txs`);
+  if (pMissing > 0) broke("S5_p_missing", `recipient P missing from ${pMissing} withdraw txs`, "low", "recipient not present");
+
+  // ════════════════════════════════════════════════════════════════════════
+  // S7 — FORGED R in memo while paying the REAL P. Withdraw should still land
+  //   (R is off-chain only, not consumed on-chain) but a payee scanning the
+  //   forged R must NOT find P -> documents the availability seam: R integrity
+  //   is the sender's responsibility, not enforced on-chain.
+  // ════════════════════════════════════════════════════════════════════════
+  console.log(`\n[S7] forged R in the withdraw memo while paying the REAL P (off-chain R seam)`);
+  results.scenarios.push("S7_forged_R_in_memo_seam");
+  // Use the SECOND fresh pool path quickly: derive a payment, but announce a DIFFERENT R.
+  // (Reuse freshPoolRun-like flow but with a mismatched memo.)
+  {
+    const auth3 = Keypair.generate();
+    const [cfg3] = PublicKey.findProgramAddressSync([SEEDS.config, auth3.publicKey.toBuffer()], POOL_PROGRAM);
+    const [vault3] = PublicKey.findProgramAddressSync([SEEDS.vault, cfg3.toBuffer()], POOL_PROGRAM);
+    const leaf3 = (i) => PublicKey.findProgramAddressSync([SEEDS.leaf, cfg3.toBuffer(), u64le(i)], POOL_PROGRAM)[0];
+    const nul3 = (n) => PublicKey.findProgramAddressSync([SEEDS.nullifier, cfg3.toBuffer(), Buffer.from(n, "hex")], POOL_PROGRAM)[0];
+    {
+      const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("confirmed");
+      const tx = new Transaction({ blockhash, lastValidBlockHeight, feePayer: wallet.publicKey })
+        .add(SystemProgram.transfer({ fromPubkey: wallet.publicKey, toPubkey: auth3.publicKey, lamports: 600_000_000 }));
+      tx.sign(wallet);
+      const sig = await conn.sendRawTransaction(tx.serialize(), { skipPreflight: true });
+      await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
+    }
+    const init3 = new TransactionInstruction({ programId: POOL_PROGRAM, keys: [
+      { pubkey: cfg3, isSigner: false, isWritable: true }, { pubkey: vault3, isSigner: false, isWritable: true },
+      { pubkey: auth3.publicKey, isSigner: true, isWritable: true }, sysAccount,
+    ], data: Buffer.concat([Buffer.from([0x00]), u64le(DENOM)]) });
+    await send([init3], [auth3], auth3.publicKey, "S7-init");
+    const pk3 = Buffer.from(cfg3.toBytes()).toString("hex");
+    const c3A = genSecretHex(), c3B = genSecretHex();
+    const sc = witnessSpec({ poolKeyHex: pk3, recipientHex: "05" + "00".repeat(31), relayerHex, spendIndex: 0, secretsHex: [c3A, c3B] });
+    for (let i = 0; i < 2; i++) {
+      const dep = new TransactionInstruction({ programId: POOL_PROGRAM, keys: [
+        { pubkey: cfg3, isSigner: false, isWritable: true }, { pubkey: vault3, isSigner: false, isWritable: true },
+        { pubkey: leaf3(i), isSigner: false, isWritable: true }, { pubkey: auth3.publicKey, isSigner: true, isWritable: true }, sysAccount,
+      ], data: Buffer.concat([Buffer.from([0x01]), Buffer.from(sc.commitmentsHex[i], "hex")]) });
+      await send([cuIx(400_000), dep], [auth3], auth3.publicKey, `S7-dep${i}`);
+    }
+    const ai = await conn.getAccountInfo(cfg3, "confirmed");
+    const root3 = Buffer.from(ai.data.slice(44, 76)).toString("hex");
+    const pm = derive(meta, randomBytes(32));
+    const Pn = new PublicKey(pm.stealthPub);
+    const sp = witnessSpec({ poolKeyHex: pk3, recipientHex: Buffer.from(pm.stealthPub).toString("hex"), relayerHex, spendIndex: 0, secretsHex: [c3A, c3B] });
+    const pr = prove(sp);
+    // FORGE the announced R: random 32 bytes that are a valid point but NOT pm.ephemPub
+    const forgedR = derive(meta, randomBytes(32)).ephemPub;
+    const wIx = new TransactionInstruction({ programId: POOL_PROGRAM, keys: [
+      { pubkey: cfg3, isSigner: false, isWritable: true }, { pubkey: vault3, isSigner: false, isWritable: true },
+      { pubkey: nul3(pr.publicInputsHex.nullifier), isSigner: false, isWritable: true },
+      { pubkey: Pn, isSigner: false, isWritable: true }, { pubkey: relayer.publicKey, isSigner: true, isWritable: true }, sysAccount,
+    ], data: Buffer.concat([Buffer.from([0x02]), Buffer.from(pr.publicInputsHex.nullifier, "hex"), Buffer.from(root3, "hex"),
+      Buffer.from(pr.proof256Hex, "hex"), Pn.toBuffer(), relayer.publicKey.toBuffer(), u64le(FEE)]) });
+    const ann = `nullpay:v1:${payee.NAME}.null:R=${Buffer.from(forgedR).toString("hex")}`;
+    const mIx = new TransactionInstruction({ programId: MEMO_PROGRAM_ID, keys: [], data: Buffer.from(ann, "utf8") });
+    const r = await send([cuIx(1_400_000), wIx, mIx], [relayer], relayer.publicKey, "S7-forgedR");
+    const landed = r.executed;
+    // payee scans the FORGED R -> must NOT match the real P
+    const scanForged = scan(payee.keys, { stealthPub: pm.stealthPub, ephemPub: forgedR });
+    // payee scans the REAL R (recovered out-of-band) -> matches
+    const scanReal = scan(payee.keys, pm);
+    if (landed && !scanForged && scanReal) {
+      hold("S7_forged_R_seam",
+        "forged-R withdraw lands on-chain (R is off-chain, not verified by the program) but the payee scanning the forged R cannot find P; only the real R locates P");
+    } else if (scanForged) {
+      broke("S7_forged_R_match", "a forged R produced a scan match (R is not binding to the derived P)", "medium", `sig=${r.sig}`);
+    } else if (!landed) {
+      // not a bug per se, but unexpected for this flow
+      hold("S7_forged_R_seam", `withdraw with forged-R memo did not land (${errName(r.logs, r.err)}); on-chain does not depend on R either way`);
+    }
+  }
+
+  // ---- summary ----
+  results.poolConfig = poolConfig.toBase58();
+  results.payeeName = `${payee.NAME}.null`;
+  console.log(`\n=== MAYHEM SUMMARY ===`);
+  console.log(`scenarios run: ${results.scenarios.length}`);
+  console.log(`HELD: ${results.held.length}  BROKE: ${results.broke.length}`);
+  mkdirSync(join(REPO, "evidence"), { recursive: true });
+  writeFileSync(join(REPO, "evidence", "fusion-mayhem-devnet.json"), JSON.stringify(results, null, 2) + "\n");
+  console.log("evidence -> evidence/fusion-mayhem-devnet.json");
+}
+
+main().catch((e) => { console.error("\nMAYHEM HARNESS ERROR:", e.stack || String(e)); process.exit(1); });

--- a/build/zk/prove-v3.mjs
+++ b/build/zk/prove-v3.mjs
@@ -13,8 +13,16 @@
  * The on-chain public-input ORDER must match the circuit's `public [...]` list:
  *   public [nullifier, merkle_root, recipient, pool_id, relayer, fee, denomination]
  *
- * Optional 3rd arg: a path to an ALTERNATE zkey/wasm/vk triple base dir, used by the
- * e2e to prove under the TRUSTLESS ceremony VK. Defaults to the single-party pilot.
+ * VK SELECTION (SWV3_VK_MODE env, default "ceremony"):
+ *   - ceremony : the BEACON-SEALED multi-contribution key under
+ *       ceremony/shielded_withdraw_v3/ (alpha_g1.x=2d4d9aa7…). This is the VK the
+ *       DEPLOYED devnet pool program embeds, so it is the ONLY mode whose proofs the
+ *       program accepts on-chain. Default.
+ *   - pilot    : the single-party key under build/zk/ (alpha_g1.x=2f881452…). Proofs
+ *       verify LOCALLY but the deployed program rejects them with Custom(4)=ProofInvalid,
+ *       so this mode is REFUSED here (exit 1) unless the caller forces explicit paths.
+ * SWV3_ZKEY / SWV3_VK env override the resolved zkey/vk paths directly (highest
+ * priority — e.g. for a local-only pilot proof, set both to the pilot paths).
  */
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync, existsSync } from "node:fs";
@@ -23,12 +31,41 @@ import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, "..", "..");
 const SNARKJS = join(HERE, "node_modules", "snarkjs", "build", "cli.cjs");
 const WASM = join(HERE, "out", "shielded_withdraw_v3_js", "shielded_withdraw_v3.wasm");
 
-// zkey/vk source: pilot (default) or, if SWV3_ZKEY/SWV3_VK env set, the ceremony VK.
-const ZKEY = process.env.SWV3_ZKEY ?? join(HERE, "ceremony", "shielded_withdraw_v3_final.zkey");
-const VK = process.env.SWV3_VK ?? join(HERE, "out", "shielded_withdraw_v3_vk.json");
+// zkey/vk source — see header. ceremony (default) is what the deployed program embeds;
+// pilot is refused unless explicit SWV3_ZKEY/SWV3_VK are set.
+const VK_SOURCES = {
+  ceremony: {
+    zkey: join(REPO, "ceremony", "shielded_withdraw_v3", "shielded_withdraw_v3_final.zkey"),
+    vk: join(REPO, "ceremony", "shielded_withdraw_v3", "shielded_withdraw_v3_vk.json"),
+  },
+  pilot: {
+    zkey: join(HERE, "ceremony", "shielded_withdraw_v3_final.zkey"),
+    vk: join(HERE, "out", "shielded_withdraw_v3_vk.json"),
+  },
+};
+const VK_MODE = (process.env.SWV3_VK_MODE ?? "ceremony").toLowerCase();
+const explicitZkey = process.env.SWV3_ZKEY, explicitVk = process.env.SWV3_VK;
+const hasExplicit = !!(explicitZkey || explicitVk);
+if (!hasExplicit && VK_MODE === "pilot") {
+  console.error(
+    "prove-v3.mjs: vk-mode=pilot is refused.\n" +
+    "  The deployed devnet pool program embeds the CEREMONY verifying key; pilot\n" +
+    "  (single-party) proofs are rejected on-chain with Custom(4)=ProofInvalid.\n" +
+    "  Use vk-mode=ceremony (the default). For a local-only pilot proof, set BOTH\n" +
+    "  SWV3_ZKEY and SWV3_VK to the pilot paths explicitly.");
+  process.exit(1);
+}
+if (!hasExplicit && !(VK_MODE in VK_SOURCES)) {
+  console.error(`prove-v3.mjs: unknown SWV3_VK_MODE '${VK_MODE}' (expected 'ceremony' or 'pilot')`);
+  process.exit(1);
+}
+const source = VK_SOURCES[VK_MODE] ?? VK_SOURCES.ceremony;
+const ZKEY = explicitZkey ?? source.zkey;
+const VK = explicitVk ?? source.vk;
 
 const specPath = process.argv[2];
 const outPath = process.argv[3];
@@ -87,10 +124,14 @@ const g2 = (p) => { const [xc0, xc1] = p[0], [yc0, yc1] = p[1];
 const proof256 = Buffer.concat([g1(proof.pi_a), g2(proof.pi_b), g1(proof.pi_c)]);
 if (proof256.length !== 256) throw new Error(`proof bytes ${proof256.length} != 256`);
 
+// last two path segments — ceremony & pilot share the basename, so the parent dir
+// is what actually distinguishes them (e.g. shielded_withdraw_v3/...final.zkey).
+const tail2 = (p) => p.split(/[\\/]/).slice(-2).join("/");
 const out = {
   localVerify: "OK",
-  zkey: ZKEY.split(/[\\/]/).pop(),
-  vk: VK.split(/[\\/]/).pop(),
+  vkMode: hasExplicit ? "explicit" : VK_MODE,
+  zkey: tail2(ZKEY),
+  vk: tail2(VK),
   proof256Hex: proof256.toString("hex"),
   publicSignalsDec: pub,
   publicInputsHex: {

--- a/docs/DARK_RELAY_RAIL.md
+++ b/docs/DARK_RELAY_RAIL.md
@@ -89,8 +89,11 @@ Anyone contributes via `ceremony/CONTRIBUTING_V3.md` — that is the decentraliz
 
 **Honest scope:** the dry run's contributions are simulated-independent (one operator),
 so it is **not yet trustless** — it becomes trustless when those steps are run by
-independent humans. The **drand beacon is real**. Swapping the ceremony VK into the
-verifier and re-running the e2e under it is supported via `--vk-mode ceremony`.
+independent humans. The **drand beacon is real**. The deployed devnet program embeds
+this ceremony VK, so `--vk-mode ceremony` is the **default** the e2e/fusion scripts run
+under (and `prove-v3.mjs` defaults to it). The single-party pilot VK verifies locally but
+is rejected on-chain (`Custom(4)=ProofInvalid`), so `--vk-mode pilot` is refused by the
+e2e scripts; a pilot proof only applies to a pool you deployed yourself with the pilot VK.
 
 ## 4. Devnet e2e (full unlinkability)
 


### PR DESCRIPTION
## Problem

`build/zk/prove-v3.mjs` treated `--vk-mode` as a **label only**. It always emitted **PILOT** proofs (`alpha_g1.x=2f881452…`), but the deployed devnet pool `2L7phWpE8Mkrij6oURj1mQcSPGs3oPL5ytAAQoN65nYY` embeds the **CEREMONY** VK (`alpha_g1.x=2d4d9aa7…`, see `crates/dark-groth16-core/src/shielded_withdraw_v3_vk.rs`). So the fused withdraw always failed on-chain with `Custom(4)=ProofInvalid` — correct program behavior, wrong prover. There was **no** invocation of `fusion-e2e-devnet.mjs` that could land a withdraw against the deployed program.

The two key sets share the basename `shielded_withdraw_v3_final.zkey`, which is exactly why the bug stayed invisible:
- pilot: `build/zk/ceremony/…final.zkey` + `build/zk/out/…vk.json`
- ceremony: `ceremony/shielded_withdraw_v3/…final.zkey` + `…vk.json`

## Fix

- **`prove-v3.mjs`** — centralized zkey/vk resolution; `SWV3_VK_MODE` (default **`ceremony`**) actually selects the paths. `pilot` is **refused** with a clear message unless explicit `SWV3_ZKEY`/`SWV3_VK` are set (local-only). Output now reports `vkMode` + parent-dir/basename so the two modes are distinguishable.
- **`fusion-e2e-devnet.mjs`**, **`e2e-v3-devnet.mjs`** — `--vk-mode` defaults to `ceremony`, rejects `pilot` clearly (exit 2), and `prove()` **forwards `SWV3_VK_MODE`** to the prover.
- **`fusion-mayhem-devnet.mjs`** — *(previously untracked in the worktree; added here)* forces `ceremony` in `prove()` since it lands real withdraws (S3/S5/S7) against the deployed pool.
- **docs** — README + `DARK_RELAY_RAIL.md` note ceremony as default and pilot as local-only.

**The program was NOT redeployed.**

## Verification (done)

Proven through the Rust `verify_swv3` example — the **same `groth16_verify` + `alt_bn128` code path the on-chain syscall runs** (its header: *"if it passes here it will pass the syscall on devnet"*):

```
ceremony proof (default, no env): VALID   -> deployed program accepts
pilot    proof (explicit env):    INVALID -> reproduces Custom(4)=ProofInvalid
```

All three pilot-mode guards fire (exit 1/2/2); all four scripts parse.

## ⚠️ Remaining — needs a funded agent to run on devnet

I could **not** land the full withdraw tx live this session: the devnet faucet is hard rate-limited and the signing wallet is down to ~0.008 SOL (below the 0.0095 SOL pool-config rent), so no fresh pool can be initialized. In two budget-trimmed attempts, `init` + `deposit#0` **landed on the deployed program** (real txs) and only ran out of lamports at the *second deposit* — a funding artifact, unrelated to the proof.

**To confirm and close this out**, an agent with a funded devnet wallet should run (no redeploy):

```bash
# fund the signer first (~1.3 SOL on devnet):
#   solana airdrop 2 --url devnet   # wallet: F6Fr2Sn6jLMbpLMcg7ezrwNLZxs9MM8RYyifUAvP72BY
git checkout fix/swv3-prove-ceremony-vk
node build/zk/fusion-e2e-devnet.mjs \
  2L7phWpE8Mkrij6oURj1mQcSPGs3oPL5ytAAQoN65nYY \
  --registrar CpNbE8yec5UQJGTVsiTiQpKFhXfDKQZuGWMzMyFtKkME
# expect: fused withdraw lands, P receives denom-fee (99000000), OVERALL: PASS
# also run: node build/zk/e2e-v3-devnet.mjs 2L7phWpE8Mkrij6oURj1mQcSPGs3oPL5ytAAQoN65nYY
```

Then attach the landed withdraw signature here. Tracked in the linked issue.

## Notes
- Excluded `evidence/private-rail-fusion-devnet.json` (pre-existing dirty state from an earlier `--vk-mode pilot` run — the very bug this fixes) and the untracked mayhem evidence artifact.
