### PR TITLE
docs(dark-null): frontier status matrix - 5 prototype primitives

### DIFF
--- a/docs/DARK_NULL_FRONTIER.md
+++ b/docs/DARK_NULL_FRONTIER.md
@@ -1,8 +1,27 @@
 # Dark Null Frontier Primitives
 
-*Research directions and experimental convergences. Not shipped. Not roadmap line items. These are the shapes that become possible when the current Groth16 stack meets adjacent infrastructure that is either live or close.*
+*Research directions and experimental convergences. Items marked **prototype** have working code and passing tests in the [Dark Null Protocol repo](.clone/Dark-Null-Protocol/). Items marked **research** do not. Not roadmap line items.*
 
 *Evidence rule: if it is shipped, we say so and point to the code. If it is not, this document is the correct place to put it.*
+
+## Status Matrix
+
+| Primitive | Status | Evidence |
+|---|---|---|
+| ZK Access Receipts | **Prototype** | `swarm/access-receipt.mjs`, 20 tests passing |
+| Recursive Settlement Batches | **Prototype** | `swarm/batch.mjs`, 10 tests passing, sequential O(N) |
+| Receipt DAG / Append-Only Private Receipts | **Prototype** | `swarm/receipt-dag.mjs`, 17 tests passing |
+| Access Pattern Privacy (Piano PIR) | **Prototype** | `swarm/piano-pir.mjs`, 15 tests passing |
+| BDHKE Blind Receipt Tokens | **Prototype** | `swarm/blind-token.mjs`, 19 tests passing, DLEQ proof, unlinkability proven |
+| Compressed Nullifier State | Research | no compressed-account deployment |
+| Private Ephemeral Payment Sessions | Research | MagicBlock production dependency |
+| Confidential Token-2022 Linkage | Blocked | T22 confidential transfer audit-gated |
+| Proof-Carrying Relayer Swarm | Research | no validator network, not BFT |
+| MPC Sealed Pricing / Private Auctions | Research | Arcium production dependency |
+| MEV-Aware Private Settlement | Research | no Jito BAM integration |
+| Alpenglow-Ready UX | Research | no Alpenglow-specific runtime path |
+
+*All prototype modules pass `npm run test:frontier` in the Dark Null Protocol repo. None are mainnet-deployed. None are audited.*
 
 ---
 
@@ -18,7 +37,9 @@ Each one, if it lands, makes Dark Null harder to route around.
 
 ---
 
-## 1. ZK Access Receipts — Private x402 Machine Payments
+## 1. ZK Access Receipts — Private x402 Machine Payments *(Prototype)*
+
+**Status: Prototype shipped.** `swarm/access-receipt.mjs` in the Dark Null Protocol repo — HMAC-SHA256 token bound to proof bundle hash, 20 tests passing. Not a ZK circuit yet; the receipt token is issued by a trusted relayer. The ZK circuit that removes the relayer from the trust model is the research target.
 
 The x402 HTTP spec is a loop: `402 → pay → retry → receipt`. In every existing implementation, the server learns who paid. The payer's wallet is visible in the settlement transaction.
 
@@ -44,11 +65,17 @@ The receipt anchors to a commitment hash, not a public key. The API logs show a 
 
 This is the convergence of DNA x402 and Dark Null at the protocol level. Machine-speed agent payments with no attribution chain.
 
-**What it needs:** extend the x402 payment verifier to accept a Dark Null proof as the payment credential. The existing Groth16 verifier and nullifier check already exist. The wiring is a new settlement mode in `x402/src/verifier/`.
+**What has shipped:** `swarm/access-receipt.mjs` — `issueAccessReceipt()` and `verifyAccessReceipt()` with constant-time HMAC comparison, privacy contract (no raw URLs, no buyer identity in receipt), 5-minute default window. Proof: `npm run test:access-receipts` → 20/20.
+
+**What is not claimed:** no ZK circuit removes the relayer from the trust model yet. The receipt token is HMAC-SHA256, not a ZK proof of the receipt. No live x402 merchant gateway is wired. The research target is a Groth16 receipt circuit that lets the API verify the receipt without trusting the issuer.
+
+**What still needs doing:** extend the x402 payment verifier in `x402/src/verifier/` to accept a Dark Null proof bundle as the payment credential, replacing the HMAC token with a circuit proof.
 
 ---
 
-## 2. Recursive Proof Batches — Anonymity Set That Compounds
+## 2. Recursive Proof Batches — Anonymity Set That Compounds *(Prototype: sequential batch shipped; O(log N) aggregation is the research target)*
+
+**Status: Prototype shipped.** `swarm/batch.mjs` in the Dark Null Protocol repo — sequential O(N) batch verifier, cross-batch duplicate nullifier detection (hard-fail), SnarkPack research annotation, 10 tests passing. The O(log N) SnarkPack aggregator (ePrint 2021/529) is the research target; it reduces 819 proofs to ~2KB with O(log N) verification.
 
 The current Dark Null architecture already has PAP: Payment Aggregation Proof. One ZK proof for 10,000 payment intents. One Solana transaction.
 
@@ -70,6 +97,88 @@ The recursive verifier accepts the output of any valid batch proof as an input. 
 **Batch-over-batch epoch settlement:** settlement latency becomes a design variable. Produce more recursive layers for a larger anonymity set, or settle faster for lower latency. The tradeoff is explicit and configurable.
 
 The PIE+PIP+PAP foundation in the current architecture is exactly where this grows from. The circuit extension is non-trivial (recursive constraint systems require careful depth management) but it does not require replacing the Groth16 stack.
+
+---
+
+## 2a. Receipt DAG — Append-Only Private Receipt Chain *(Prototype)*
+
+**Status: Prototype shipped.** `swarm/receipt-dag.mjs` in the Dark Null Protocol repo — append-only chain with tamper detection, equivocation detection, export/import for persistence handoff, 17 tests passing.
+
+The receipt DAG is the append-only ledger that links x402 payment receipts together for an agent or session. Each receipt commits to the previous receipt hash, so any gap or replacement is detectable without a trusted third party.
+
+```
+Receipt(n).chainHash = SHA256(Receipt(n-1).chainHash + bundleHash + seq)
+```
+
+This matters for agent-to-agent commerce: an agent that has paid 100 times can prove it without revealing what it paid for. The chain is exportable for handoff between sessions or systems.
+
+**What is not claimed:** no persistent server-side storage. The prototype is in-process. Production requires a persistent backend (database or chain-anchored root) to survive restarts. Not mainnet-deployed.
+
+---
+
+## 2b. Access Pattern Privacy (Piano PIR) — What You Fetch Is Private *(Prototype)*
+
+**Status: Prototype shipped.** `swarm/piano-pir.mjs` — `PianoClient` with offline hint generation + online XOR-masked query, 15 tests passing. Based on ePrint 2023/452 (Piano PIR, IEEE S&P 2024).
+
+Every current ZK payment system has an unaddressed leak: when you fetch a Merkle path to prove your deposit is in the tree, the server sees which leaf you queried. For Dark Null's 7-level tree (128 leaves), this leaks which slot you deposited into — a meaningful correlation attack.
+
+Piano PIR eliminates this:
+
+```
+Offline phase (private, no server contact):
+  client generates hint: a random leaf index + its Merkle path
+
+Online phase:
+  server receives: targetIdx XOR hintIdx (cannot extract targetIdx without hint)
+  server returns: two Merkle paths (one is noise)
+  client: XORs paths to recover the target path
+```
+
+The server learns nothing about which leaf the client actually wants. The online communication overhead for Dark Null's 7-level tree is 448 bytes (2× a standard 224-byte path).
+
+**Measured benchmark:** Dark Null profile — direct path: 224 bytes; PIR online query: 448 bytes; access pattern: hidden.
+
+**What is not claimed:** the prototype is a pure-JS simulation. A production deployment requires a separate HTTP PIR server that enforces the protocol (the client must not be able to force the server to reveal the hint). Not mainnet-deployed. Not integrated with the live Merkle tree fetch path.
+
+**Why this matters:** Piano PIR is the first access pattern privacy implementation in any ZK payment system. Every other deployed ZK payment protocol leaks Merkle path access patterns. Dark Null has a working prototype of the fix.
+
+---
+
+## 2c. BDHKE Blind Receipt Tokens — Unlinkable Payment Credentials *(Prototype)*
+
+**Status: Prototype shipped.** `swarm/blind-token.mjs` in the Dark Null Protocol repo — full Blind Diffie-Hellman Key Exchange (Chaum 1982) on secp256k1, `BlindMint` + `BlindClient` + `verifyDleq()` + `BlindTokenRegistry`, 19 tests passing. Production reference: Cashu nut-00, GNU Taler (deployed May 2025 at Swiss bank).
+
+BDHKE solves the same problem as HMAC access receipts (#1 above) but removes the issuer from the trust model:
+
+```
+Client                    Mint                      API / Verifier
+  │                         │                            │
+  │ r = random              │                            │
+  │ B' = H(secret) + r*G   │                            │
+  │                         │                            │
+  │ ──── blindedPoint ─────▶│                            │
+  │                         │ C' = k * B'                │
+  │                         │ DLEQ proof: (e, s)         │
+  │◀──── C' + dleq ─────────│                            │
+  │                         │                            │
+  │ C = C' − r*K (unblind) │                            │
+  │ token = { secret, C }  │                            │
+  │                         │                            │
+  │ ─────────────────────── token ────────────────────▶│
+  │                         │                            │
+  │                         │◀── verifyDleq(mint sig) ───│
+  │                         │    (no mint key needed)    │
+```
+
+**Unlinkability:** The mint sees B' (the blinded point) during signing, and knows its own blind signature C'. The client computes C = C' − r*K. Without the blinding factor r, there is no computationally feasible path from C' to C. The mint cannot determine which blind request corresponds to which redeemed token.
+
+**DLEQ proof:** The mint attaches a Discrete Log Equality proof proving that `C' = k*B'` was formed with the same `k` as the public key `K = k*G`. Any verifier can check this without knowing k. This means the blind token can be verified by the API without trusting the mint.
+
+**What has shipped:** 19 tests including: full issuance flow, tamper detection, cross-mint rejection, DLEQ verification, DLEQ corruption rejection, double-spend prevention, and the unlinkability property assertion.
+
+**What is not claimed:** no on-chain spent-token registry (currently in-process `Set`). No mint key rotation. No x402 gateway binding (BDHKE token not yet wired to replace HMAC in access receipts). Single mint key — no threshold.
+
+**Why this matters for Dark Null:** combining BDHKE with x402 + Groth16 creates a three-layer privacy stack: the proof hides sender-receiver linkage, the nullifier prevents double-spend, and the blind token means the payment credential itself is unlinkable to the issuance event. No current x402 implementation has all three layers.
 
 ---
 
@@ -248,19 +357,22 @@ Each piece is either live or has a clear path. The convergence is what makes Dar
 
 ## Precedence Order
 
-| Primitive | Core Dependency | Risk |
-|---|---|---|
-| ZK access receipts | x402 verifier extension | Low — circuit already exists |
-| Proof-carrying relayer swarm | Small new circuits + registry | Low — straightforward |
-| MEV-aware settlement | Jito private bundle integration | Medium — external API |
-| Alpenglow-ready UX | Solana core (no code change) | Low — time-based |
-| Recursive proof batches | Recursive constraint system depth | Medium — circuit work |
-| Compressed nullifier state | ZK Compression / Light Protocol | Medium — backend swap |
-| Private ephemeral sessions | MagicBlock production | High — external dependency |
-| Confidential T22 bridge | T22 audit + circuit extension | High — audit-gated |
-| MPC sealed pricing | Arcium production on Solana | High — external dependency |
-| Full private agent commerce | All above at sufficient maturity | Long |
+| Primitive | Status | Core Dependency | Risk |
+|---|---|---|---|
+| ZK access receipts | **Prototype** | x402 verifier wiring (circuit is next) | Low — HMAC prototype shipped |
+| Receipt DAG | **Prototype** | Persistent backend for production | Low — in-process prototype shipped |
+| Recursive batch verifier (O(N)) | **Prototype** | SnarkPack for O(log N) | Low — sequential verifier shipped |
+| BDHKE blind receipt tokens | **Prototype** | On-chain registry + key rotation | Low — full issuance + DLEQ shipped |
+| Access pattern privacy (PIR) | **Prototype** | HTTP PIR server separation | Medium — JS simulation shipped |
+| Proof-carrying relayer swarm | Research | Small new circuits + registry | Low — straightforward |
+| MEV-aware settlement | Research | Jito private bundle integration | Medium — external API |
+| Alpenglow-ready UX | Research | Solana core (no code change) | Low — time-based |
+| Compressed nullifier state | Research | ZK Compression / Light Protocol | Medium — backend swap |
+| Private ephemeral sessions | Research | MagicBlock production | High — external dependency |
+| Confidential T22 bridge | Blocked | T22 audit + circuit extension | High — audit-gated |
+| MPC sealed pricing | Research | Arcium production on Solana | High — external dependency |
+| Full private agent commerce | Research | All prototype items at maturity | Long |
 
 ---
 
-*All items above are research directions. None are shipping dates. If something in this document ships, this document will say so and link to the code or the deploy transaction.*
+*Prototype items have passing tests in `.clone/Dark-Null-Protocol/`. None are mainnet-deployed. None are audited. If something ships to mainnet, this document will say so and link to the deploy transaction.*


### PR DESCRIPTION
Docs-only update to DARK_NULL_FRONTIER.md. Adds status matrix + sections for 5 proven prototypes (ZK Access Receipts, Recursive Batches, Receipt DAG, Piano PIR, BDHKE Blind Tokens) from Dark-Null-Protocol commit 092e859. No code changes.