### PR TITLE
feat(receipt-dag): cross-layer accountability DAG + proof-of-accountability verifier

### DIFF
--- a/build/zk/mainnet-anchor.mjs
+++ b/build/zk/mainnet-anchor.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Anchor a real cross-layer accountability root on Solana MAINNET via the LIVE
+ * `receipt_anchor` program (6HSRGivd…) — no new deploy, just a transaction.
+ *
+ * Builds a cross-layer DAG batch (a payment → a private x402 access bound to it),
+ * commits its Merkle root to the on-chain bucket accumulator, then reads the bucket
+ * back and verifies the accumulation. Deterministic values → reproducible root.
+ *
+ * Env: RPC (mainnet), KEY (payer keypair), DAG (path to receipt-dag src).
+ */
+import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+
+const RPC = process.env.RPC ?? "https://api.mainnet-beta.solana.com";
+const KEY = process.env.KEY ?? "/key.json";
+const DAG = process.env.DAG ?? "/work/dag/src/index.ts";
+
+const {
+  buildDagReceipt, buildX402AccessReceipt, verifyDagChain, traceProvenance,
+  buildDagMerkleRoot, anchorDagRoot, hashAction, RECEIPT_ANCHOR_PROGRAM_ID,
+} = await import(DAG);
+const { Connection, Keypair, PublicKey } = await import("@solana/web3.js");
+
+const payer = Keypair.fromSecretKey(Uint8Array.from(JSON.parse(readFileSync(KEY, "utf8"))));
+const conn = new Connection(RPC, "confirmed");
+const before = await conn.getBalance(payer.publicKey);
+console.log(`payer ${payer.publicKey.toBase58()}  mainnet bal ${before / 1e9} SOL`);
+console.log(`anchor program ${RECEIPT_ANCHOR_PROGRAM_ID} (live mainnet)\n`);
+
+// ── a real cross-layer batch: agent pays, then privately proves access bound to that payment ──
+const AGENT = "web0:agent-commitment:demo";
+const payment = buildDagReceipt({
+  agentPubkey: AGENT, layer: "payment", sequenceNonce: 0, timestamp: 1_000,
+  actionHash: hashAction({ layer: "payment", amount: "5000", asset: "USDC", note: "x402 settlement" }),
+});
+const access = buildX402AccessReceipt({
+  agentPubkey: AGENT,
+  scopeHash: hashAction({ resource: "x402://api.web0.null/inference" }),
+  epoch: 7,
+  nullifier: hashAction({ nullifier: "single-use-access-token" }),
+  fundingReceiptId: payment.receiptId,
+  sequenceNonce: 1, parentReceiptId: payment.receiptId, timestamp: 2_000,
+});
+const batch = [payment, access];
+
+const vr = verifyDagChain(batch);
+const prov = traceProvenance(access.receiptId, batch);
+const root = buildDagMerkleRoot(batch).toString("hex");
+console.log(`DAG valid: ${vr.valid}   access traces: ${[...prov.reachedLayers].join(" + ")}`);
+console.log(`cross-layer accountability root: ${root}\n`);
+
+// ── commit it on mainnet (default programId = the live 6HSRGivd). Fresh bucket for a clean verify. ──
+const bucketId = BigInt(Date.now());
+const ar = await anchorDagRoot(batch, conn, payer, { bucketId });
+
+// ── verify the on-chain bucket accumulated it: root == SHA-256([0;32] || anchor), count == 1 ──
+const acc = await conn.getAccountInfo(new PublicKey(ar.bucketPda), "confirmed");
+const onRoot = Buffer.from(acc.data.slice(14, 46)).toString("hex");
+const onCount = acc.data.readUInt32LE(10);
+const expect = createHash("sha256").update(Buffer.concat([Buffer.alloc(32), Buffer.from(ar.anchor, "hex")])).digest("hex");
+const verified = onRoot === expect && onCount === 1;
+const after = await conn.getBalance(payer.publicKey);
+
+console.log(`✅ ANCHORED ON MAINNET`);
+console.log(`   tx        ${ar.signature}`);
+console.log(`   bucket    ${ar.bucketPda}  (count=${onCount}, accumulated-root verified=${verified})`);
+console.log(`   cost      ${((before - after) / 1e9).toFixed(6)} SOL  (remaining ${(after / 1e9).toFixed(6)})`);
+console.log(`   solscan   https://solscan.io/tx/${ar.signature}`);
+console.log(`   bucket    https://solscan.io/account/${ar.bucketPda}`);
+process.exit(verified ? 0 : 1);

--- a/build/zk/verify-accountability.mjs
+++ b/build/zk/verify-accountability.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Proof-of-accountability verifier (read-only) — anyone can run this.
+ * Reconstructs the exact cross-layer batch (payment -> private x402 access) that was
+ * anchored on Solana MAINNET, then verifies via the receipt-dag library that:
+ *   (1) the DAG chain is valid (anti-equivocation + parent linkage),
+ *   (2) its Merkle root matches, and
+ *   (3) that root is the one anchored in the live receipt_anchor bucket.
+ * No keys, no writes — pure read against the live program. Trust nobody, verify the root.
+ *
+ * Env: RPC (mainnet), DAG (receipt-dag src), BUCKET (the anchored bucket PDA).
+ */
+const RPC = process.env.RPC ?? "https://api.mainnet-beta.solana.com";
+const DAG = process.env.DAG ?? "/work/dag/src/index.ts";
+const BUCKET = process.env.BUCKET ?? "Ejr4XWczALR1GQ4T9ksaw9wfW3npZ5s7rYf7Dw6npXrc";
+
+const { buildDagReceipt, buildX402AccessReceipt, buildDagMerkleRoot, verifyAccountability, traceProvenance, hashAction } =
+  await import(DAG);
+const { Connection } = await import("@solana/web3.js");
+const conn = new Connection(RPC, "confirmed");
+
+// Reconstruct the exact deterministic batch that was anchored (must match mainnet-anchor.mjs).
+const AGENT = "web0:agent-commitment:demo";
+const payment = buildDagReceipt({
+  agentPubkey: AGENT, layer: "payment", sequenceNonce: 0, timestamp: 1000,
+  actionHash: hashAction({ layer: "payment", amount: "5000", asset: "USDC", note: "x402 settlement" }),
+});
+const access = buildX402AccessReceipt({
+  agentPubkey: AGENT, scopeHash: hashAction({ resource: "x402://api.web0.null/inference" }),
+  epoch: 7, nullifier: hashAction({ nullifier: "single-use-access-token" }),
+  fundingReceiptId: payment.receiptId, sequenceNonce: 1, parentReceiptId: payment.receiptId, timestamp: 2000,
+});
+const batch = [payment, access];
+
+const root = buildDagMerkleRoot(batch).toString("hex");
+const prov = traceProvenance(access.receiptId, batch);
+console.log(`rebuilt cross-layer root: ${root}`);
+console.log(`access provenance traces: ${[...prov.reachedLayers].join(" + ")}`);
+
+const verdict = await verifyAccountability(batch, conn, { bucketPda: BUCKET });
+console.log(JSON.stringify(verdict, (_k, v) => (typeof v === "bigint" ? v.toString() : v), 2));
+console.log(
+  verdict.accountable
+    ? "\n✅ ACCOUNTABLE — chain valid + Merkle root anchored on Solana MAINNET, verified read-only against the live receipt_anchor bucket. No trust in web0 required."
+    : "\n❌ NOT verified — see verdict above."
+);
+process.exit(verdict.accountable ? 0 : 1);

--- a/packages/receipt-dag/package.json
+++ b/packages/receipt-dag/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "tsc --noEmit",
-    "test": "node --test tests/merkle.test.mjs tests/cross-layer.test.mjs"
+    "test": "node --test tests/merkle.test.mjs tests/cross-layer.test.mjs tests/verify-accountability.test.mjs"
   },
   "keywords": [
     "solana",

--- a/packages/receipt-dag/src/index.ts
+++ b/packages/receipt-dag/src/index.ts
@@ -543,3 +543,121 @@ export function traceProvenance(
   }
   return { ancestors: [...ancestors.values()], reachedLayers };
 }
+
+// ── Proof-of-accountability verifier ──────────────────────────────────────────────
+// Anyone holding the receipts can verify the chain AND that its root is the one anchored
+// on-chain — WITHOUT trusting the issuer. Reads the receipt_anchor bucket and checks the
+// accumulated root. (For a fresh single-anchor bucket, count==1 and
+// bucket.root == SHA-256([0;32] || anchoredRoot); a multi-anchor bucket needs the full
+// anchor sequence to verify a lone root, which we surface rather than fake.)
+
+export interface VerifyAnchoredRootResult {
+  anchored: boolean;
+  bucketPda: string;
+  onChainRoot: string | null; // hex
+  count: number | null;
+  bucketId: bigint | null;
+  matchesFreshAccumulator: boolean | null;
+  note?: string;
+}
+
+export interface AccountabilityVerdict {
+  accountable: boolean;
+  chainValid: boolean;
+  chainViolation?: string;
+  merkleRoot: string; // hex
+  rootAnchored: boolean;
+  layersCovered: ReceiptLayer[];
+  anchor: VerifyAnchoredRootResult;
+}
+
+/** AnchorBucket layout: [ver1][bump1][bucket_id8 LE][count4 LE][root32][updated_at8 LE]. */
+function parseAnchorBucket(data: Uint8Array): { bucketId: bigint; count: number; root: string } {
+  const b = Buffer.from(data);
+  return {
+    bucketId: b.readBigUInt64LE(2),
+    count: b.readUInt32LE(10),
+    root: Buffer.from(b.subarray(14, 46)).toString("hex"),
+  };
+}
+
+/**
+ * Verify that `rootHex` was anchored into a receipt_anchor bucket. Pass either the
+ * `bucketPda` (read it directly) or the `bucketId` (derive the PDA). Read-only.
+ */
+/**
+ * PURE accumulator check (no chain, no web3.js) — does `rootHex` match what a fresh
+ * (count==1) receipt_anchor bucket accumulated? bucket.root == SHA-256([0;32] || root).
+ * Exported so the verification logic is testable offline against raw bucket bytes.
+ */
+export function checkAccumulatedRoot(
+  rootHex: string,
+  bucketData: Uint8Array
+): Omit<VerifyAnchoredRootResult, "bucketPda"> {
+  const { bucketId, count, root: onChainRoot } = parseAnchorBucket(bucketData);
+  const expectFresh = sha256buf(Buffer.concat([Buffer.alloc(32), Buffer.from(rootHex, "hex")])).toString("hex");
+  let matchesFreshAccumulator: boolean | null = null;
+  let note: string | undefined;
+  if (count === 1) {
+    matchesFreshAccumulator = onChainRoot === expectFresh;
+  } else {
+    note = `bucket count=${count}; a lone root only verifies directly against a fresh (count==1) bucket — multi-anchor buckets need the full anchor sequence`;
+  }
+  const r: Omit<VerifyAnchoredRootResult, "bucketPda"> = {
+    anchored: matchesFreshAccumulator === true, onChainRoot, count, bucketId, matchesFreshAccumulator,
+  };
+  if (note !== undefined) r.note = note;
+  return r;
+}
+
+export async function verifyAnchoredRoot(
+  rootHex: string,
+  connection: Connection,
+  options: { programId?: string; bucketId?: bigint; bucketPda?: string }
+): Promise<VerifyAnchoredRootResult> {
+  const { PublicKey } = await import("@solana/web3.js");
+  const programId = new PublicKey(options.programId ?? RECEIPT_ANCHOR_PROGRAM_ID);
+
+  let bucketPda: InstanceType<typeof PublicKey>;
+  if (options.bucketPda !== undefined) {
+    bucketPda = new PublicKey(options.bucketPda);
+  } else if (options.bucketId !== undefined) {
+    const le = Buffer.alloc(8); le.writeBigUInt64LE(options.bucketId);
+    bucketPda = PublicKey.findProgramAddressSync([Buffer.from(RECEIPT_ANCHOR_BUCKET_SEED), le], programId)[0];
+  } else {
+    throw new Error("verifyAnchoredRoot: pass bucketPda or bucketId");
+  }
+
+  const acc = await connection.getAccountInfo(bucketPda, "confirmed");
+  if (acc === null) {
+    return { anchored: false, bucketPda: bucketPda.toBase58(), onChainRoot: null, count: null, bucketId: null, matchesFreshAccumulator: null, note: "bucket account not found" };
+  }
+  return { ...checkAccumulatedRoot(rootHex, acc.data), bucketPda: bucketPda.toBase58() };
+}
+
+/**
+ * One-call proof of accountability: given the receipt batch (payment -> access -> job),
+ * verify the DAG chain (anti-equivocation + parent linkage), recompute its Merkle root,
+ * and confirm that root is anchored on-chain. Returns a structured verdict.
+ */
+export async function verifyAccountability(
+  batch: DagReceipt[],
+  connection: Connection,
+  options: { programId?: string; bucketId?: bigint; bucketPda?: string }
+): Promise<AccountabilityVerdict> {
+  const chain = verifyDagChain(batch);
+  const merkleRoot = buildDagMerkleRoot(batch).toString("hex");
+  const anchor = await verifyAnchoredRoot(merkleRoot, connection, options);
+  const layers = new Set<ReceiptLayer>();
+  for (const r of batch) if (r.layer !== undefined) layers.add(r.layer);
+  const out: AccountabilityVerdict = {
+    accountable: chain.valid && anchor.anchored,
+    chainValid: chain.valid,
+    merkleRoot,
+    rootAnchored: anchor.anchored,
+    layersCovered: [...layers],
+    anchor,
+  };
+  if (chain.violation !== undefined) out.chainViolation = chain.violation;
+  return out;
+}

--- a/packages/receipt-dag/tests/verify-accountability.test.mjs
+++ b/packages/receipt-dag/tests/verify-accountability.test.mjs
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  buildDagReceipt, buildX402AccessReceipt, verifyDagChain,
+  buildDagMerkleRoot, checkAccumulatedRoot, hashAction,
+} from "../src/index.ts";
+
+const AGENT = "web0:agent:verify-test";
+const sha = (b) => createHash("sha256").update(b).digest();
+
+// Craft a receipt_anchor bucket account: [ver1][bump1][bucket_id8 LE][count4 LE][root32][updated8].
+function bucketAccount({ count = 1, rootHex }) {
+  const b = Buffer.alloc(54);
+  b[0] = 1; b[1] = 255;
+  b.writeBigUInt64LE(123n, 2);
+  b.writeUInt32LE(count, 10);
+  Buffer.from(rootHex, "hex").copy(b, 14);
+  b.writeBigInt64LE(0n, 46);
+  return b;
+}
+// The on-chain root a FRESH bucket holds after anchoring `anchorHex`.
+const freshAccumulated = (anchorHex) =>
+  sha(Buffer.concat([Buffer.alloc(32), Buffer.from(anchorHex, "hex")])).toString("hex");
+
+function accountabilityBatch() {
+  const payment = buildDagReceipt({
+    agentPubkey: AGENT, layer: "payment", sequenceNonce: 0, timestamp: 1,
+    actionHash: hashAction({ layer: "payment", amount: "5000" }),
+  });
+  const access = buildX402AccessReceipt({
+    agentPubkey: AGENT, scopeHash: "scope-1", epoch: 7, nullifier: "null-1",
+    fundingReceiptId: payment.receiptId, sequenceNonce: 1, parentReceiptId: payment.receiptId, timestamp: 2,
+  });
+  return [payment, access];
+}
+
+test("checkAccumulatedRoot: a fresh (count=1) bucket holding our root verifies", () => {
+  const root = buildDagMerkleRoot(accountabilityBatch()).toString("hex");
+  const acc = bucketAccount({ count: 1, rootHex: freshAccumulated(root) });
+  const r = checkAccumulatedRoot(root, acc);
+  assert.equal(r.anchored, true);
+  assert.equal(r.matchesFreshAccumulator, true);
+  assert.equal(r.count, 1);
+});
+
+test("checkAccumulatedRoot: a bucket holding a DIFFERENT root does not verify", () => {
+  const root = buildDagMerkleRoot(accountabilityBatch()).toString("hex");
+  const acc = bucketAccount({ count: 1, rootHex: freshAccumulated("ab".repeat(32)) }); // someone else's root
+  const r = checkAccumulatedRoot(root, acc);
+  assert.equal(r.anchored, false);
+  assert.equal(r.matchesFreshAccumulator, false);
+});
+
+test("checkAccumulatedRoot: a multi-anchor (count>1) bucket can't verify a lone root (honest null)", () => {
+  const root = buildDagMerkleRoot(accountabilityBatch()).toString("hex");
+  const acc = bucketAccount({ count: 2, rootHex: freshAccumulated(root) });
+  const r = checkAccumulatedRoot(root, acc);
+  assert.equal(r.matchesFreshAccumulator, null);
+  assert.equal(r.anchored, false);
+  assert.match(r.note, /count=2/);
+});
+
+test("full accountability (offline): valid chain + anchored root = accountable", () => {
+  const batch = accountabilityBatch();
+  const chain = verifyDagChain(batch);
+  const root = buildDagMerkleRoot(batch).toString("hex");
+  const anchor = checkAccumulatedRoot(root, bucketAccount({ count: 1, rootHex: freshAccumulated(root) }));
+  const accountable = chain.valid && anchor.anchored;
+  assert.equal(accountable, true);
+});
+
+test("full accountability: an equivocating batch is NOT accountable even if a root is anchored", () => {
+  const a = buildDagReceipt({ agentPubkey: AGENT, layer: "payment", sequenceNonce: 0, actionHash: hashAction("x") });
+  const dup = buildDagReceipt({ agentPubkey: AGENT, layer: "job", sequenceNonce: 0, actionHash: hashAction("y") }); // same nonce
+  const batch = [a, dup];
+  const chain = verifyDagChain(batch);
+  const root = buildDagMerkleRoot(batch).toString("hex");
+  const anchor = checkAccumulatedRoot(root, bucketAccount({ count: 1, rootHex: freshAccumulated(root) }));
+  assert.equal(chain.valid, false);       // equivocation caught
+  assert.equal(anchor.anchored, true);    // the bytes are anchored, but...
+  assert.equal(chain.valid && anchor.anchored, false); // ...not accountable
+});


### PR DESCRIPTION
Cross-layer anti-equivocation receipt DAG (v0.3.0) + the **proof-of-accountability verifier**: anyone can verify the receipt chain AND that its Merkle root is anchored on-chain, **with zero trust in web0** — one read-only call, no key.

- `verifyAccountability(batch, conn, {bucketPda|bucketId})` + pure `checkAccumulatedRoot()`
- **19/19** unit tests; **proven read-only against the live mainnet anchor** (root `22f0926a…`, bucket `Ejr4XWcz`, count=1 → `accountable: true`)
- CLI: `build/zk/verify-accountability.mjs`