### PR TITLE
feat: three proven privacy primitives (accountability proof pack, blind-BLS ecash, ed25519 stealth)

### DIFF
--- a/build/zk/ecash-null-killtest.mjs
+++ b/build/zk/ecash-null-killtest.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * ECASH-NULL — blind-BLS bearer cash kill-test on BN254 (the curve `sol_alt_bn128_group_op`
+ * exposes on Solana MAINNET today). Routes AROUND the Ristretto / sol_curve_* path that gates
+ * dark_fedimint_redeem on mainnet: the Chaumian DLEQ check is replaced by a 2-pairing BLS check
+ *   e(sigma, G2) == e(M, K)      (i.e. e(sigma,G2) * e(M, -K) == 1)
+ * which BN254 supports on mainnet now. The mint blind-signs without seeing the token (unlinkable),
+ * the user unblinds, and redemption is a pairing check + a single-use nullifier.
+ *
+ * Offline kill-test — no chain, no mainnet write. Proves the math, the blinding correctness,
+ * double-spend rejection, and forgery rejection. (Production note: M must be hash-to-curve to
+ * the G1 subgroup; here M = h(serial)·G1 is sufficient to exercise the pairing/blinding logic.)
+ */
+import { randomBytes, createHash } from "node:crypto";
+const { bn254 } = await import("@noble/curves/bn254");
+
+const G1 = bn254.G1.ProjectivePoint;
+const G2 = bn254.G2.ProjectivePoint;
+const Fr = bn254.fields.Fr;
+const Fp12 = bn254.fields.Fp12;
+
+const rndScalar = () => {
+  let s = 0n;
+  while (s === 0n) s = BigInt("0x" + randomBytes(32).toString("hex")) % Fr.ORDER;
+  return s;
+};
+const hashToScalar = (buf) => {
+  const h = BigInt("0x" + createHash("sha256").update(buf).digest("hex")) % Fr.ORDER;
+  return h === 0n ? 1n : h;
+};
+// message point in G1 (production: hash-to-curve; here h(serial)*G1 exercises the same algebra)
+const M_of = (serial) => G1.BASE.multiply(hashToScalar(serial));
+// e(sigma,G2) == e(M,K)
+const verifyToken = (sigma, M, K) =>
+  Fp12.eql(bn254.pairing(sigma, G2.BASE), bn254.pairing(M, K));
+
+// ── mint setup ─────────────────────────────────────────────────────────────────
+const k = rndScalar();              // mint secret
+const K = G2.BASE.multiply(k);      // mint public key in G2
+
+// ── issue a token, blinded (the mint never sees the token serial) ────────────────
+const serial = randomBytes(16);     // the bearer token's secret serial
+const M = M_of(serial);             // token message point
+const r = rndScalar();              // user blinding factor
+const Mb = M.multiply(r);           // blinded message handed to the mint
+const Sb = Mb.multiply(k);          // mint blind-signs: k * (r*M)
+const S = Sb.multiply(Fr.inv(r));   // user unblinds: r^-1 * Sb = k*M  (valid BLS sig on M)
+
+const results = {};
+
+// 1. a legit token redeems
+results.legit_token_verifies = verifyToken(S, M, K);
+
+// 2. the mint learned NOTHING linkable: its view (Mb) is r*M for random r — unlinkable to M
+//    (sanity: Mb != M, and the unblinded S is nonetheless a valid signature on M)
+results.blinding_unlinkable = !Mb.equals(M) && verifyToken(S, M, K);
+
+// 3. double-spend: the nullifier (serial commitment) is single-use
+const seen = new Set();
+const nullifier = createHash("sha256").update(serial).digest("hex");
+const redeem = (sig, msg) => {
+  if (!verifyToken(sig, msg, K)) return "rejected:bad-signature";
+  if (seen.has(nullifier)) return "rejected:double-spend";
+  seen.add(nullifier);
+  return "accepted";
+};
+const first = redeem(S, M);
+const second = redeem(S, M);
+results.first_redeem_accepted = first === "accepted";
+results.double_spend_rejected = second === "rejected:double-spend";
+
+// 4. forged signature (no mint key) fails the pairing
+const forged = G1.BASE.multiply(rndScalar());
+results.forged_signature_rejected = !verifyToken(forged, M, K);
+
+// 5. signature is bound to its message — can't move it to another token
+const otherM = M_of(randomBytes(16));
+results.wrong_message_rejected = !verifyToken(S, otherM, K);
+
+// 6. wrong mint key fails (token only valid under the issuing mint)
+const K2 = G2.BASE.multiply(rndScalar());
+results.wrong_mint_rejected = !verifyToken(S, M, K2);
+
+console.log("=== ECASH-NULL — blind-BLS bearer cash on BN254 (mainnet alt_bn128 curve) ===");
+const checks = [
+  ["legit token verifies (2-pairing check)", results.legit_token_verifies],
+  ["blind-sign is unlinkable + still valid", results.blinding_unlinkable],
+  ["first redeem accepted", results.first_redeem_accepted],
+  ["double-spend rejected (nullifier)", results.double_spend_rejected],
+  ["forged signature rejected", results.forged_signature_rejected],
+  ["signature bound to its message", results.wrong_message_rejected],
+  ["wrong mint key rejected", results.wrong_mint_rejected],
+];
+for (const [label, ok] of checks) console.log(`  ${ok ? "PASS" : "FAIL"}  ${label}`);
+const pass = checks.every(([, ok]) => ok);
+console.log(`\nRESULT: ${pass
+  ? "PASS — Chaumian blind-BLS bearer cash verifies with a 2-pairing check on BN254. No Ristretto, no SIMD-0388, no trusted setup — the verify backend is live on Solana mainnet today."
+  : "FAIL"}`);
+process.exit(pass ? 0 : 1);

--- a/build/zk/nullpay-stealth-killtest.mjs
+++ b/build/zk/nullpay-stealth-killtest.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * NullPay Stealth Inbox — offline crypto kill-test for the ed25519 explicit-scalar core.
+ *
+ * Pay a `.null`, funds land on a fresh ONE-TIME ed25519 address only the recipient can sweep.
+ * The make-or-break claim (already landed on devnet, evidence/nullpay-stealth-devnet.json):
+ * a stealth-derived scalar — which is NOT bit-clamped like a normal ed25519 seed — still
+ * produces a signature that STOCK RFC-8032 ed25519 verify accepts (so Solana accepts the sweep).
+ *
+ * This proves it offline (no chain, no mainnet write): real ed25519 ECDH stealth derivation,
+ * recipient recovers the one-time secret, signs with the explicit unclamped scalar, and the
+ * signature verifies under @noble's stock ed25519.verify. Plus the unlinkability adversary check.
+ */
+import { createHash, randomBytes } from "node:crypto";
+const { ed25519 } = await import("@noble/curves/ed25519");
+
+const Point = ed25519.Point ?? ed25519.ExtendedPoint;
+const L = ed25519.CURVE.n; // group order
+const sha512 = (...b) => createHash("sha512").update(Buffer.concat(b.map(Buffer.from))).digest();
+const leToInt = (buf) => { let n = 0n; for (let i = buf.length - 1; i >= 0; i--) n = (n << 8n) | BigInt(buf[i]); return n; };
+const intToLE32 = (n) => { const b = Buffer.alloc(32); for (let i = 0; i < 32; i++) { b[i] = Number(n & 0xffn); n >>= 8n; } return b; };
+const modL = (buf) => { const r = leToInt(buf) % L; return r === 0n ? 1n : r; };
+const rndScalar = () => modL(randomBytes(64));
+
+// Sign message m with an EXPLICIT scalar a (no clamping) under pubkey A=a*G — RFC-8032 shape.
+function signExplicit(a, A, m) {
+  const Abytes = A.toRawBytes();
+  const r = modL(sha512(Buffer.from("nullpay-nonce-v1"), intToLE32(a), m)); // deterministic nonce
+  const R = Point.BASE.multiply(r);
+  const Rbytes = R.toRawBytes();
+  const k = modL(sha512(Rbytes, Abytes, m)); // challenge
+  const s = (r + k * a) % L;
+  return Buffer.concat([Rbytes, intToLE32(s)]); // 64-byte signature
+}
+
+const results = {};
+
+// ── recipient publishes a stealth meta-address: scan + spend keypairs (real ed25519 points) ──
+const scanSk = rndScalar(), spendSk = rndScalar();
+const Scan = Point.BASE.multiply(scanSk);
+const Spend = Point.BASE.multiply(spendSk);
+
+// ── sender: derive a one-time address P from the published meta + a random ephemeral ──────────
+const ephSk = rndScalar();
+const Eph = Point.BASE.multiply(ephSk);
+const sharedSender = sha512(Buffer.from("stealth-ecdh-v1"), Scan.multiply(ephSk).toRawBytes()); // ECDH eph*Scan
+const tSender = modL(sharedSender);
+const P = Spend.add(Point.BASE.multiply(tSender)); // one-time pubkey = Spend + t*G
+
+// ── recipient: recompute shared from Eph, recover the one-time SECRET scalar ───────────────────
+const sharedRecip = sha512(Buffer.from("stealth-ecdh-v1"), Eph.multiply(scanSk).toRawBytes()); // ECDH scan*Eph
+const tRecip = modL(sharedRecip);
+const p = (spendSk + tRecip) % L; // one-time secret (UNCLAMPED)
+const Precovered = Point.BASE.multiply(p);
+
+results.ecdh_shared_matches = Buffer.compare(sharedSender, sharedRecip) === 0;
+results.recovered_secret_controls_address = Precovered.equals(P);
+
+// ── the unclamped one-time scalar signs a sweep that STOCK ed25519 verify accepts ─────────────
+const sweepMsg = Buffer.from("nullpay:sweep one-time note -> recipient main wallet");
+const sig = signExplicit(p, P, sweepMsg);
+results.explicit_scalar_sig_verifies_stock = ed25519.verify(sig, sweepMsg, P.toRawBytes());
+
+// the scalar is genuinely NOT clamped (a normal ed25519 seed clamps bits 0-2 of byte0 + bit 6/7 of byte31)
+const pLE = intToLE32(p);
+const isClamped = (pLE[0] & 0b111) === 0 && (pLE[31] & 0b1100_0000) === 0b0100_0000;
+results.scalar_is_unclamped = !isClamped;
+
+// ── adversary: a wrong key cannot sign for P; a tampered message fails ─────────────────────────
+results.wrong_key_cannot_sign = !ed25519.verify(signExplicit(rndScalar(), Point.BASE.multiply(rndScalar()), sweepMsg), sweepMsg, P.toRawBytes());
+results.tampered_message_rejected = !ed25519.verify(sig, Buffer.from("nullpay:sweep -> ATTACKER wallet"), P.toRawBytes());
+
+// ── unlinkability: without scanSk, P reveals nothing linking it to Spend/Scan ──────────────────
+const P2 = Spend.add(Point.BASE.multiply(modL(sha512(Buffer.from("stealth-ecdh-v1"), Scan.multiply(rndScalar()).toRawBytes()))));
+results.distinct_payments_unlinkable = !P.equals(P2) && !P.equals(Spend) && !P.equals(Scan);
+
+console.log("=== NullPay Stealth Inbox — ed25519 explicit-scalar one-time address (offline) ===");
+const checks = [
+  ["ECDH shared secret matches (sender == recipient)", results.ecdh_shared_matches],
+  ["recovered one-time secret controls the address", results.recovered_secret_controls_address],
+  ["one-time scalar is UNCLAMPED (not a normal seed)", results.scalar_is_unclamped],
+  ["explicit-scalar sig verifies under STOCK ed25519", results.explicit_scalar_sig_verifies_stock],
+  ["wrong key cannot sign for the address", results.wrong_key_cannot_sign],
+  ["tampered sweep message rejected", results.tampered_message_rejected],
+  ["distinct payments unlinkable (no scan key)", results.distinct_payments_unlinkable],
+];
+for (const [label, ok] of checks) console.log(`  ${ok ? "PASS" : "FAIL"}  ${label}`);
+const pass = checks.every(([, ok]) => ok);
+console.log(`\nRESULT: ${pass
+  ? "PASS — a stealth-derived UNCLAMPED ed25519 scalar produces a signature stock RFC-8032 verify accepts (so Solana accepts the sweep). One-time addresses are unlinkable. Matches the devnet evidence; the on-chain leg waits for the founder."
+  : "FAIL"}`);
+process.exit(pass ? 0 : 1);

--- a/build/zk/proof-of-agency.mjs
+++ b/build/zk/proof-of-agency.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Proof-of-Agency — a portable, paste-to-verify "proof pack" for an AI agent's action.
+ *
+ * Encodes a cross-layer receipt batch (payment -> private x402 access) into a compact
+ * base64url string (deflate). ANYONE can decode it and verify, read-only and keyless, that
+ * the action was payment-backed, non-equivocating, and anchored on Solana MAINNET — with zero
+ * trust in web0. Two fixtures prove the claim AND its failure mode:
+ *   - the REAL pack (the batch actually anchored)        -> must verify GREEN (accountable)
+ *   - a forged-but-internally-valid pack (different root) -> must go RED (not the anchored root)
+ *
+ * Local proof/kill. No on-chain writes — a single read of the live bucket.
+ * Env: RPC (mainnet), DAG (receipt-dag src), BUCKET (the anchored bucket PDA).
+ */
+import { deflateRawSync, inflateRawSync } from "node:zlib";
+
+const RPC = process.env.RPC ?? "https://api.mainnet-beta.solana.com";
+const DAG = process.env.DAG ?? "/work/dag/src/index.ts";
+const BUCKET = process.env.BUCKET ?? "Ejr4XWczALR1GQ4T9ksaw9wfW3npZ5s7rYf7Dw6npXrc";
+
+const { buildDagReceipt, buildX402AccessReceipt, verifyAccountability, traceProvenance, hashAction } =
+  await import(DAG);
+const { Connection } = await import("@solana/web3.js");
+const conn = new Connection(RPC, "confirmed");
+
+const b64url = {
+  enc: (buf) => buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, ""),
+  dec: (s) => Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/"), "base64"),
+};
+// pack = base64url(deflate(JSON{ v, bucketPda, batch })) — a shareable proof string / QR payload
+const pack = (batch, bucketPda) => b64url.enc(deflateRawSync(Buffer.from(JSON.stringify({ v: 1, bucketPda, batch }))));
+const unpack = (s) => JSON.parse(inflateRawSync(b64url.dec(s)).toString());
+
+// The exact deterministic batch anchored on mainnet (must match mainnet-anchor.mjs / verify-accountability.mjs).
+const AGENT = "web0:agent-commitment:demo";
+const realPayment = buildDagReceipt({
+  agentPubkey: AGENT, layer: "payment", sequenceNonce: 0, timestamp: 1000,
+  actionHash: hashAction({ layer: "payment", amount: "5000", asset: "USDC", note: "x402 settlement" }),
+});
+const realAccess = buildX402AccessReceipt({
+  agentPubkey: AGENT, scopeHash: hashAction({ resource: "x402://api.web0.null/inference" }),
+  epoch: 7, nullifier: hashAction({ nullifier: "single-use-access-token" }),
+  fundingReceiptId: realPayment.receiptId, sequenceNonce: 1, parentReceiptId: realPayment.receiptId, timestamp: 2000,
+});
+const realBatch = [realPayment, realAccess];
+
+// A forged batch: internally consistent (chain valid) but a DIFFERENT amount -> different root.
+const fakePayment = buildDagReceipt({
+  agentPubkey: AGENT, layer: "payment", sequenceNonce: 0, timestamp: 1000,
+  actionHash: hashAction({ layer: "payment", amount: "9999999", asset: "USDC", note: "forged" }),
+});
+const fakeAccess = buildX402AccessReceipt({
+  agentPubkey: AGENT, scopeHash: hashAction({ resource: "x402://api.web0.null/inference" }),
+  epoch: 7, nullifier: hashAction({ nullifier: "single-use-access-token" }),
+  fundingReceiptId: fakePayment.receiptId, sequenceNonce: 1, parentReceiptId: fakePayment.receiptId, timestamp: 2000,
+});
+const fakeBatch = [fakePayment, fakeAccess];
+
+async function verifyPack(label, packStr) {
+  const { batch, bucketPda } = unpack(packStr);                 // decode (anyone can do this)
+  const v = await verifyAccountability(batch, conn, { bucketPda }); // read-only mainnet check
+  const prov = traceProvenance(batch[batch.length - 1].receiptId, batch);
+  return { label, len: packStr.length, accountable: v.accountable, chainValid: v.chainValid,
+    rootAnchored: v.rootAnchored, traces: [...(prov.reachedLayers || [])].join("+"),
+    root: (v.merkleRoot || "").slice(0, 16) };
+}
+
+const realPack = pack(realBatch, BUCKET);
+const fakePack = pack(fakeBatch, BUCKET);
+console.log(`real proof pack  (${realPack.length} chars): ${realPack.slice(0, 56)}…`);
+console.log(`forged proof pack(${fakePack.length} chars): ${fakePack.slice(0, 56)}…\n`);
+
+const real = await verifyPack("REAL  ", realPack);
+const fake = await verifyPack("FORGED", fakePack);
+for (const r of [real, fake]) console.log(JSON.stringify(r));
+
+const pass =
+  real.accountable === true && real.rootAnchored === true && real.traces.includes("payment") &&
+  fake.accountable === false && fake.rootAnchored === false &&
+  unpack(realPack).batch.length === realBatch.length;
+
+console.log(`\nRESULT: ${pass
+  ? "PASS — the real proof pack verifies GREEN against the live mainnet anchor; a forged-but-valid pack goes RED (its root was never anchored). Paste-to-verify works, keyless, no trust in web0."
+  : "FAIL — see verdicts above."}`);
+process.exit(pass ? 0 : 1);

--- a/evidence/zk/ecash-null-blind-bls-killtest.json
+++ b/evidence/zk/ecash-null-blind-bls-killtest.json
@@ -1,0 +1,22 @@
+{
+  "name": "ECASH-NULL — Chaumian blind-BLS bearer cash on BN254",
+  "date": "2026-06-22",
+  "layer": "crypto kill-test (offline, no chain)",
+  "claim": "Unlinkable Chaumian bearer cash whose redemption is a 2-pairing BLS check e(sigma,G2)==e(M,K) on BN254 — the curve sol_alt_bn128_group_op exposes on Solana mainnet TODAY. Routes around the Ristretto / sol_curve_* syscall (and SIMD-0388 BLS12-381 pairing) that gates dark_fedimint_redeem on mainnet, with no trusted setup.",
+  "scheme": "Mint sk k, pk K=k*G2. User: serial m -> M in G1, blind r, hands Mb=r*M to the mint (mint never sees the token). Mint blind-signs Sb=k*Mb. User unblinds S=r^-1*Sb=k*M. Redeem: verify e(S,G2)==e(M,K) and consume a single-use nullifier=H(serial).",
+  "tooling": "@noble/curves/bn254 (pairing + G1/G2 + Fp12.eql), node, sandboxed docker --network none",
+  "script": "build/zk/ecash-null-killtest.mjs",
+  "result": "PASS (7/7)",
+  "checks": {
+    "legit token verifies (2-pairing check)": true,
+    "blind-sign is unlinkable + still valid": true,
+    "first redeem accepted": true,
+    "double-spend rejected (nullifier)": true,
+    "forged signature rejected": true,
+    "signature bound to its message": true,
+    "wrong mint key rejected": true
+  },
+  "reuses": "Keeps ~80% of programs/dark_fedimint_redeem (nullifier, double-spend PDA, payout); swaps the DLEQ verify for the alt_bn128 2-pairing check.",
+  "production_notes": "M must be hash-to-curve to the G1 subgroup (here M=h(serial)*G1 exercises the pairing/blinding algebra). On-chain verify = one alt_bn128_pairing call e(S,G2)*e(M,-K)==1. Next step: a ~1-day litesvm Rust kill-test of the same equation against the real alt_bn128 software backend, then wire into a dark_fedimint_redeem variant.",
+  "status": "Proven at the math layer. Not yet an on-chain program. Publish as a proven primitive + design, not a shipped product."
+}

--- a/evidence/zk/nullpay-stealth-ed25519-killtest.json
+++ b/evidence/zk/nullpay-stealth-ed25519-killtest.json
@@ -1,0 +1,22 @@
+{
+  "name": "NullPay Stealth Inbox — ed25519 explicit-scalar one-time address",
+  "date": "2026-06-22",
+  "layer": "crypto kill-test (offline, no chain, no mainnet write)",
+  "claim": "Pay a .null name; funds land on a fresh one-time ed25519 address only the recipient can sweep. The make-or-break: a stealth-derived scalar (NOT bit-clamped like a normal ed25519 seed) still produces a signature that STOCK RFC-8032 ed25519 verify accepts, so Solana accepts the sweep.",
+  "scheme": "Recipient publishes meta = (Scan=scan_sk*G, Spend=spend_sk*G). Sender: ephemeral Eph=eph_sk*G, ECDH shared=H(eph_sk*Scan), t=H(shared), one-time P=Spend+t*G. Recipient: shared=H(scan_sk*Eph) (DH symmetry), one-time secret p=(spend_sk+t) mod L, p*G==P. Sweep signed with the explicit unclamped p.",
+  "tooling": "@noble/curves/ed25519 (Point ops + stock ed25519.verify), manual RFC-8032 explicit-scalar sign, sandboxed docker --network none",
+  "script": "build/zk/nullpay-stealth-killtest.mjs",
+  "result": "PASS (7/7)",
+  "checks": {
+    "ECDH shared secret matches (sender == recipient)": true,
+    "recovered one-time secret controls the address": true,
+    "one-time scalar is UNCLAMPED (not a normal seed)": true,
+    "explicit-scalar sig verifies under STOCK ed25519": true,
+    "wrong key cannot sign for the address": true,
+    "tampered sweep message rejected": true,
+    "distinct payments unlinkable (no scan key)": true
+  },
+  "corroborates": "evidence/nullpay-stealth-devnet.json — the SAME claim already landed on devnet (real pay_stealth + sweep tx 31g9mZbg…, stealth address 2Qgsac4Q…, metaRoundtrip/fundsLanded/scanDetected PASS).",
+  "reuses": "crates/dark-stealth-ed25519, dark-stealth-address, dark-batch-stealth-scan (view-tag O(1) scan); live R1 registrar SetStealthMeta (IX 0x06); NullDomain.x402_endpoint to publish the ephemeral.",
+  "status": "Crypto core PROVEN offline + devnet-proven on-chain. The remaining work is off-chain TS glue (sender derive / recipient scan+sweep) against the LIVE registrar — that leg involves a real on-chain write and waits for the founder. Publish the proof + the design; do not write mainnet unattended."
+}


### PR DESCRIPTION
Crypto kill-tests for three privacy primitives, each proven at the crypto layer — offline / live-read only, no mainnet writes.

- **proof-of-agency.mjs** — a portable base64url proof pack anyone verifies keyless, read-only, against the live mainnet receipt_anchor (6HSRGivd): real pack -> accountable/rootAnchored true; a forged-but-valid pack -> rootAnchored false (its root was never anchored). You can't forge a verifying pack.
- **ecash-null-killtest.mjs** — Chaumian blind-BLS bearer cash, 7/7: redemption is a 2-pairing check e(s,G2)==e(M,K) on BN254 (the alt_bn128 curve live on mainnet today); unlinkable blind-sign, double-spend + forgery rejected.
- **nullpay-stealth-killtest.mjs** — ed25519 one-time stealth address, 7/7: a stealth-derived unclamped scalar produces a signature stock RFC-8032 verify accepts; unlinkable. Corroborates existing devnet evidence.

Evidence in evidence/zk/. Proven primitives + designs — the on-chain products are the next build, not claimed shipped.